### PR TITLE
Add dummy composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,29 @@
+{
+  "name": "talis/php-client",
+  "description": "This is a php client library for talis api's",
+  "version": "0.0.1",
+  "keywords": [
+    "persona",
+    "echo",
+    "babel",
+    "critic",
+    "php",
+    "client library"
+  ],
+  "homepage": "https://github.com/talis/talis-php",
+  "type": "library",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Malcolm Landon",
+      "email": "ml@talis.com",
+      "homepage": "http://engineering.talis.com"
+    }
+  ],
+  "require": {
+    "php": ">=5.3.0"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "4.8.36"
+  }
+}


### PR DESCRIPTION
Trying to perform a composer install of the branch containing the first version of this library is failing.

Despite the composer.json file specifying the branch, looking at the output of composer output, we're suspicious it is still expecting a composer.json file in the master branch.

This PR, therefore, adds a bar bones composer.json file into the master branch.