### PR TITLE
90% - PLAT-1980 - Skip etag/cache header validation for /auth/keys

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "talis/talis-php",
   "description": "This is a php client library for talis api's",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "keywords": [
     "persona",
     "echo",

--- a/src/Talis/Persona/Client/Base.php
+++ b/src/Talis/Persona/Client/Base.php
@@ -179,14 +179,15 @@ abstract class Base
 
     /**
      * Create a http client
-     * @param boolean $skipRevalidation whether to skip the validation of the
-     *    remote etag/cache headers to ensure that the cached response is still
-     *    valid, or trust the originally set expiry time
+     * @param boolean $skipRevalidation whether to skip validating a previous
+     *    request that has been cached. The validation uses the remote server
+     *    to retrieve the current etag/cache headers & compare them against the
+     *    original values.
      * @return \Guzzle\Http\Client
      */
     protected function getHTTPClient($skipRevalidation = false)
     {
-        return $this->httpClientFactory->create();
+        return $this->httpClientFactory->create($skipRevalidation);
     }
 
     /**

--- a/src/Talis/Persona/Client/Base.php
+++ b/src/Talis/Persona/Client/Base.php
@@ -178,9 +178,13 @@ abstract class Base
     }
 
     /**
+     * Create a http client
+     * @param boolean $skipRevalidation whether to skip the validation of the
+     *    remote etag/cache headers to ensure that the cached response is still
+     *    valid, or trust the originally set expiry time
      * @return \Guzzle\Http\Client
      */
-    protected function getHTTPClient()
+    protected function getHTTPClient($skipRevalidation = false)
     {
         return $this->httpClientFactory->create();
     }
@@ -254,6 +258,7 @@ abstract class Base
                 'addContentType' => true,
                 'parseJson' => true,
                 'cacheTTL' => $this->defaultTtl,
+                'skipRevalidation' => false,
             ],
             $opts
         );
@@ -283,7 +288,8 @@ abstract class Base
             $httpConfig['headers']['Content-Type'] = 'application/x-www-form-urlencoded';
         }
 
-        $request = $this->getHTTPClient()->createRequest(
+        $client = $this->getHTTPClient($opts['skipRevalidation']);
+        $request = $client->createRequest(
             $opts['method'],
             $url,
             $opts['headers'],
@@ -309,6 +315,9 @@ abstract class Base
      *      addContentType: (default true) add type application/x-www-form-urlencoded
      *      parseJson: (default true) parse the response as JSON
      *      cacheTTL: optional TTL for this request only
+     *      skipRevalidation: (default false) whether to skip http cache
+     *          validation of the etags/cache headers and only use the expiry
+     *          time which was set from the original request
      * @return array|null response body
      * @throws NotFoundException If the http status was a 404
      * @throws \Exception If response not 200 and valid JSON

--- a/src/Talis/Persona/Client/HttpClientFactory.php
+++ b/src/Talis/Persona/Client/HttpClientFactory.php
@@ -3,10 +3,13 @@
 namespace Talis\Persona\Client;
 
 use \Guzzle\Plugin\Cache\CacheStorageInterface;
+use \Guzzle\Plugin\Cache\DefaultRevalidation;
 use \Guzzle\Plugin\Cache\DefaultCacheStorage;
+use \Guzzle\Plugin\Cache\SkipRevalidation;
 use \Guzzle\Cache\DoctrineCacheAdapter;
 use \Guzzle\Plugin\Cache\CachePlugin;
 use \Guzzle\Http\Client;
+
 use \Doctrine\Common\Cache\CacheProvider;
 
 class HttpClientFactory
@@ -54,12 +57,21 @@ class HttpClientFactory
 
     /**
      * Create a http client with caching that adheres to common caching rules
+     *
+     * @param boolean $skipRevalidation whether to skip validating a previous
+     *    request that has been cached. The validation uses the remote server
+     *    to retrieve the current etag/cache headers & compare them against the
+     *    original values.
      * @return \Guzzle\Http\Client
      */
-    public function create()
+    public function create($skipRevalidation = false)
     {
         $httpClient = $this->createGuzzleClient();
-        $cachePlugin = $this->createCachePlugin($this->createStorage());
+        $cachePlugin = $this->createCachePlugin(
+            $this->createStorage(),
+            $skipRevalidation
+        );
+
         $httpClient->addSubscriber($cachePlugin);
         return $httpClient;
     }
@@ -93,10 +105,22 @@ class HttpClientFactory
      * Create a cache plugin which includes mechanisms for caching http calls
      * and revalidation of the original request/responses.
      * @param CacheStorageInterface $storage object to store the cache
+     * @param boolean $skipRevalidation whether to skip validating a previous
+     *     request that has been cached. The validation uses the remote server
+     *     to retrieve the current etag/cache headers & compare them against the
+     *     original values.
      * @return CachePlugin
      */
-    protected function createCachePlugin(CacheStorageInterface $storage)
-    {
+    protected function createCachePlugin(
+        CacheStorageInterface $storage,
+        $skipRevalidation = false
+    ) {
+        if ($skipRevalidation) {
+            $revalidation = new SkipRevalidation();
+        } else {
+            $revalidation = new DefaultRevalidation($storage);
+        }
+
         return new CachePlugin(
             [
                 'storage' => $storage,

--- a/src/Talis/Persona/Client/HttpClientFactory.php
+++ b/src/Talis/Persona/Client/HttpClientFactory.php
@@ -125,6 +125,7 @@ class HttpClientFactory
             [
                 'storage' => $storage,
                 'auto_purge' => $this->config['autoPurge'],
+                'revalidation' => $revalidation,
             ]
         );
     }

--- a/src/Talis/Persona/Client/HttpClientFactory.php
+++ b/src/Talis/Persona/Client/HttpClientFactory.php
@@ -39,7 +39,7 @@ class HttpClientFactory
         array $opts = []
     ) {
         if (empty($host) || empty($cacheBackend)) {
-            throw new InvalidArgumentException('invalid arguments');
+            throw new \InvalidArgumentException('invalid arguments');
         }
 
         $this->host = $host;

--- a/src/Talis/Persona/Client/Tokens.php
+++ b/src/Talis/Persona/Client/Tokens.php
@@ -143,6 +143,7 @@ class Tokens extends Base
                 'addContentType' => true,
                 'parseJson' => false,
                 'cacheTTL' => $cacheTTL,
+                'skipRevalidation' => true,
             ]
         );
     }

--- a/test/unit/Persona/HttpClientFactoryTest.php
+++ b/test/unit/Persona/HttpClientFactoryTest.php
@@ -127,4 +127,36 @@ class HttpClientFactoryTest extends TestBase
 
         $this->assertEquals('body', $response->getBody());
     }
+
+    public function testSkipRevalidation()
+    {
+        $cacheBackend = new ArrayCache();
+
+        $factory = new HttpClientFactory(
+            'http://localhost',
+            $cacheBackend
+        );
+
+        $httpClient = $factory->create();
+        $plugin = new MockPlugin();
+        $plugin->addResponse(new Response(
+            200,
+            ['ETag' => '1c3-54c7d0388d415'],
+            'body'
+        ));
+
+        $httpClient->addSubscriber($plugin);
+
+        $request = $httpClient->createRequest('get', '/test/path');
+        $response = $request->send();
+
+        // create a client that skip revalidation
+        $skipRevalidation = true;
+        $httpClient = $factory->create($skipRevalidation);
+        $request = $httpClient->createRequest('get', '/test/path');
+        $response = $request->send();
+
+        $this->assertEquals('body', $response->getBody());
+    }
+
 }

--- a/test/unit/Persona/HttpClientFactoryTest.php
+++ b/test/unit/Persona/HttpClientFactoryTest.php
@@ -175,4 +175,16 @@ class HttpClientFactoryTest extends TestBase
 
         $this->assertEquals('body', $response->getBody());
     }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testInvalidHost()
+    {
+        $cacheBackend = new ArrayCache();
+        $factory = new HttpClientFactory(
+            null,
+            $cacheBackend
+        );
+    }
 }

--- a/test/unit/Persona/HttpClientFactoryTest.php
+++ b/test/unit/Persona/HttpClientFactoryTest.php
@@ -154,9 +154,10 @@ class HttpClientFactoryTest extends TestBase
         $skipRevalidation = true;
         $httpClient = $factory->create($skipRevalidation);
         $request = $httpClient->createRequest('get', '/test/path');
+
+        // a exception is thrown if Guzzle attempts to make the request
         $response = $request->send();
 
         $this->assertEquals('body', $response->getBody());
     }
-
 }

--- a/test/unit/Persona/HttpClientFactoryTest.php
+++ b/test/unit/Persona/HttpClientFactoryTest.php
@@ -128,6 +128,20 @@ class HttpClientFactoryTest extends TestBase
         $this->assertEquals('body', $response->getBody());
     }
 
+    /**
+     * Test that when retrieving the public certificate used for verifying the
+     * JWT tokens that the revalidation routine is skipped. The reason for this
+     * configuration is that we know that we want to cache the certificate for a
+     * fixed amount of time. The default configuration will attempt to
+     * revalidate the original request by calling the remote endpoint to verify
+     * the cache/etag headers.
+     *
+     * The test below registers a single response within the mock framework in
+     * Guzzle. The first request will consume the response and the plugin will
+     * be left empty. The expectation is that the second request will use the
+     * cache. If the cache is not used the mock framework will throw a exception
+     * as there are no more responses registered.
+     */
     public function testSkipRevalidation()
     {
         $cacheBackend = new ArrayCache();
@@ -155,7 +169,8 @@ class HttpClientFactoryTest extends TestBase
         $httpClient = $factory->create($skipRevalidation);
         $request = $httpClient->createRequest('get', '/test/path');
 
-        // a exception is thrown if Guzzle attempts to make the request
+        // a exception is thrown by the MockPlugin if Guzzle attempts to make
+        // the request
         $response = $request->send();
 
         $this->assertEquals('body', $response->getBody());

--- a/test/unit/Persona/TokensTest.php
+++ b/test/unit/Persona/TokensTest.php
@@ -1,11 +1,13 @@
 <?php
 
 use \Firebase\JWT\JWT;
-use Talis\Persona\Client\Tokens;
-use Talis\Persona\Client\ValidationResults;
-use Talis\Persona\Client\ScopesNotDefinedException;
-use Talis\Persona\Client\TokenValidationException;
-use Talis\Persona\Client\InvalidTokenException;
+use \Talis\Persona\Client\Tokens;
+use \Talis\Persona\Client\ValidationResults;
+use \Talis\Persona\Client\ScopesNotDefinedException;
+use \Talis\Persona\Client\TokenValidationException;
+use \Talis\Persona\Client\InvalidTokenException;
+use \Talis\Persona\Client\HttpClientFactory;
+use \Doctrine\Common\Cache\ArrayCache;
 
 $appRoot = dirname(dirname(dirname(__DIR__)));
 if (!defined('APPROOT')) {
@@ -954,4 +956,46 @@ class TokensTest extends TestBase
         $this->setExpectedException(InvalidTokenException::class);
         $mockClient->listScopes($accessToken);
     }
+
+   public function testRetrieveJWTCertificateSkipsRevalidation()
+   {
+
+       $cacheBackend = new ArrayCache();
+
+       $plugin = new Guzzle\Plugin\Mock\MockPlugin();
+       $plugin->addResponse(new Guzzle\Http\Message\Response(
+           200,
+           ['ETag' => '1c3-54c7d0388d415'],
+           'certificate body'
+       ));
+
+       $httpClient = new Guzzle\Http\Client('http://localhost');
+       $httpClient->addSubscriber($plugin);
+
+       $httpClientFactory = $this->getMock(
+           '\Talis\Persona\Client\HttpClientFactory',
+           ['create'],
+           [
+               'http://localhost',
+               $cacheBackend
+           ]
+       );
+
+       $httpClientFactory->expects($this->once())
+           ->method('create')
+           ->with(true) // check the skipRevalidation is set
+           ->willReturn($httpClient);
+
+       $client = new Tokens(
+            [
+                'userAgent' => 'unittest',
+                'persona_host' => 'localhost',
+                'cacheBackend' => $this->cacheBackend,
+                'httpClientFactory' => $httpClientFactory,
+            ]
+       );
+
+       $cert = $client->retrieveJWTCertificate();
+       $this->assertEquals('certificate body', $cert);
+   }
 }

--- a/test/unit/Persona/TokensTest.php
+++ b/test/unit/Persona/TokensTest.php
@@ -959,7 +959,6 @@ class TokensTest extends TestBase
 
    public function testRetrieveJWTCertificateSkipsRevalidation()
    {
-
        $cacheBackend = new ArrayCache();
 
        $plugin = new Guzzle\Plugin\Mock\MockPlugin();


### PR DESCRIPTION
the http caching for /auth/keys was validating the etag/cache headers
against the remote server (persona) for every payload/scope validation.
The changes within this commit ensure that the original expiry time set
for the certificate is kept & the remote server is not contacted until
the certificate has expired.

For more details see `vendor/guzzle/guzzle/src/Guzzle/Plugin/Cache/DefaultRevalidation.php` within the RL project.