### PR TITLE
90% - PLAT-1980 - Refactor http client

### DIFF
--- a/src/Talis/Persona/Client/Base.php
+++ b/src/Talis/Persona/Client/Base.php
@@ -33,9 +33,7 @@ abstract class Base
      */
     private $logger;
 
-    /**
-     * @var \Talis\Persona\Client\HttpClientFactoryInterface
-     */
+     /** @var \Talis\Persona\Client\HttpClientFactoryInterface */
     private $httpClientFactory;
 
     /**

--- a/src/Talis/Persona/Client/Base.php
+++ b/src/Talis/Persona/Client/Base.php
@@ -68,6 +68,7 @@ abstract class Base
      *      cacheBackend: (Doctrine\Common\Cache\CacheProvider) cache storage
      *      cacheKeyPrefix: (string) optional prefix to append to the cache keys
      *      cacheDefaultTTL: (integer) optional cache TTL value
+     *      httpClientFactory: (Talis\Persona\Client\HttpClientFactoryInterface) http client factory
      * @throws \InvalidArgumentException If any of the required config parameters are missing
      * @throws \InvalidArgumentException If the user agent format is invalid
      */
@@ -179,6 +180,14 @@ abstract class Base
     }
 
     /**
+     * @return \Guzzle\Http\Client
+     */
+    protected function getHTTPClient()
+    {
+        return $this->httpClientFactory->create();
+    }
+
+    /**
      * Retrieve the Persona client version
      * @return string Persona client version
      */
@@ -276,8 +285,7 @@ abstract class Base
             $httpConfig['headers']['Content-Type'] = 'application/x-www-form-urlencoded';
         }
 
-        $client = $this->httpClientFactory->create();
-        $request = $client->createRequest(
+        $request = $this->getHTTPClient()->createRequest(
             $opts['method'],
             $url,
             $opts['headers'],

--- a/src/Talis/Persona/Client/Base.php
+++ b/src/Talis/Persona/Client/Base.php
@@ -33,7 +33,7 @@ abstract class Base
      */
     private $logger;
 
-     /** @var \Talis\Persona\Client\HttpClientFactoryInterface */
+     /** @var \Talis\Persona\Client\HttpClientFactory */
     private $httpClientFactory;
 
     /**
@@ -66,7 +66,7 @@ abstract class Base
      *      cacheBackend: (Doctrine\Common\Cache\CacheProvider) cache storage
      *      cacheKeyPrefix: (string) optional prefix to append to the cache keys
      *      cacheDefaultTTL: (integer) optional cache TTL value
-     *      httpClientFactory: (Talis\Persona\Client\HttpClientFactoryInterface) http client factory
+     *      httpClientFactory: (Talis\Persona\Client\HttpClientFactory) http client factory
      * @throws \InvalidArgumentException If any of the required config parameters are missing
      * @throws \InvalidArgumentException If the user agent format is invalid
      */

--- a/src/Talis/Persona/Client/HttpClientFactory.php
+++ b/src/Talis/Persona/Client/HttpClientFactory.php
@@ -3,14 +3,15 @@
 namespace Talis\Persona\Client;
 
 use \Guzzle\Plugin\Cache\CacheStorageInterface;
-use Guzzle\Plugin\Cache\DefaultCacheStorage;
-use Guzzle\Cache\DoctrineCacheAdapter;
+use \Guzzle\Plugin\Cache\DefaultCacheStorage;
+use \Guzzle\Cache\DoctrineCacheAdapter;
 use \Guzzle\Plugin\Cache\CachePlugin;
 use \Guzzle\Http\Client;
+use \Doctrine\Common\Cache\CacheProvider;
 
 class HttpClientFactory implements HttpClientFactoryInterface
 {
-    /** @var CacheStorageInterface Object used to cache responses */
+    /** @var CacheProvider Object used to cache responses */
     protected $cacheBackend;
 
     /** @var string endpoint to contact */
@@ -23,15 +24,15 @@ class HttpClientFactory implements HttpClientFactoryInterface
      * Constructor
      *
      * @param string $host http endpoint (format: 'protocol://host')
-     * @param CacheStorageInterface $cacheBackend cache for http responses
+     * @param DoctrineCachePlugin $cacheBackend cache for http responses
      * @param array $opts configuration options
      *      keyPrefix: prefix for the cache key (default: '')
      *      defaultTtl: time to live for the cache (default: 3600)
      *      autoPurge: automatically clear out old cache (default: true)
      */
-    public function __constructor(
+    public function __construct(
         $host,
-        CacheStorageInterface $cacheBackend,
+        CacheProvider $cacheBackend,
         array $opts = []
     ) {
         if (empty($host) || empty($cacheBackend)) {
@@ -40,9 +41,6 @@ class HttpClientFactory implements HttpClientFactoryInterface
 
         $this->host = $host;
         $this->cacheBackend = $cacheBackend;
-        print_r('>>>>>>>>>>>>>>>>>>>>>>');
-        print_r($cacheBackend);
-        print_r(' <>>>>>>>>>>>>>>>>>>>>>>');
 
         $this->config = array_merge(
             [

--- a/src/Talis/Persona/Client/HttpClientFactory.php
+++ b/src/Talis/Persona/Client/HttpClientFactory.php
@@ -9,7 +9,7 @@ use \Guzzle\Plugin\Cache\CachePlugin;
 use \Guzzle\Http\Client;
 use \Doctrine\Common\Cache\CacheProvider;
 
-class HttpClientFactory implements HttpClientFactoryInterface
+class HttpClientFactory
 {
     /** @var CacheProvider Object used to cache responses */
     protected $cacheBackend;

--- a/src/Talis/Persona/Client/HttpClientFactory.php
+++ b/src/Talis/Persona/Client/HttpClientFactory.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Talis\Persona\Client;
+
+use \Guzzle\Plugin\Cache\CacheStorageInterface;
+use Guzzle\Plugin\Cache\DefaultCacheStorage;
+use Guzzle\Cache\DoctrineCacheAdapter;
+use \Guzzle\Plugin\Cache\CachePlugin;
+use \Guzzle\Http\Client;
+
+class HttpClientFactory implements HttpClientFactoryInterface
+{
+    /** @var CacheStorageInterface Object used to cache responses */
+    protected $cacheBackend;
+
+    /** @var string endpoint to contact */
+    protected $host;
+
+    /** @var array configuration */
+    protected $config;
+
+    /**
+     * Constructor
+     *
+     * @param string $host http endpoint (format: 'protocol://host')
+     * @param CacheStorageInterface $cacheBackend cache for http responses
+     * @param array $opts configuration options
+     *      keyPrefix: prefix for the cache key (default: '')
+     *      defaultTtl: time to live for the cache (default: 3600)
+     *      autoPurge: automatically clear out old cache (default: true)
+     */
+    public function __constructor(
+        $host,
+        CacheStorageInterface $cacheBackend,
+        array $opts = []
+    ) {
+        if (empty($host) || empty($cacheBackend)) {
+            throw new InvalidArgumentException('invalid arguments');
+        }
+
+        $this->host = $host;
+        $this->cacheBackend = $cacheBackend;
+        print_r('>>>>>>>>>>>>>>>>>>>>>>');
+        print_r($cacheBackend);
+        print_r(' <>>>>>>>>>>>>>>>>>>>>>>');
+
+        $this->config = array_merge(
+            [
+                'keyPrefix' => '',
+                'defaultTtl' => 3600,
+                'autoPurge' => true,
+            ],
+            $opts
+        );
+    }
+
+    /**
+     * Create a http client with caching that adheres to common caching rules
+     * @return \Guzzle\Http\Client
+     */
+    public function create()
+    {
+        $httpClient = $this->createGuzzleClient();
+        $cachePlugin = $this->createCachePlugin($this->createStorage());
+        $httpClient->addSubscriber($cachePlugin);
+        return $httpClient;
+    }
+
+    /**
+     * Create guzzle http client instance
+     * @return \Guzzle\Http\Client
+     */
+    protected function createGuzzleClient()
+    {
+        return new Client($this->host);
+    }
+
+    /**
+     * Create storage wrapper for the cache backend
+     * @return Guzzle\Plugin\Cache\CacheStorageInterface
+     */
+    protected function createStorage()
+    {
+        $adapter = new DoctrineCacheAdapter($this->cacheBackend);
+        $storage = new DefaultCacheStorage(
+            $adapter,
+            $this->config['keyPrefix'],
+            $this->config['defaultTtl']
+        );
+
+        return $storage;
+    }
+
+    /**
+     * Create a cache plugin which includes mechanisms for caching http calls
+     * and revalidation of the original request/responses.
+     * @param CacheStorageInterface $storage object to store the cache
+     * @return CachePlugin
+     */
+    protected function createCachePlugin(CacheStorageInterface $storage)
+    {
+        return new CachePlugin(
+            [
+                'storage' => $storage,
+                'auto_purge' => $this->config['autoPurge'],
+            ]
+        );
+    }
+}

--- a/src/Talis/Persona/Client/HttpClientFactoryInterface.php
+++ b/src/Talis/Persona/Client/HttpClientFactoryInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Talis\Persona\Client;
+
+interface HttpClientFactoryInterface
+{
+    public function create();
+}

--- a/src/Talis/Persona/Client/HttpClientFactoryInterface.php
+++ b/src/Talis/Persona/Client/HttpClientFactoryInterface.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Talis\Persona\Client;
-
-interface HttpClientFactoryInterface
-{
-    public function create();
-}

--- a/test/unit/Persona/HttpClientFactoryTest.php
+++ b/test/unit/Persona/HttpClientFactoryTest.php
@@ -1,0 +1,130 @@
+<?php
+
+$appRoot = dirname(dirname(dirname(__DIR__)));
+require_once $appRoot . '/test/unit/TestBase.php';
+
+use \Talis\Persona\Client\Login;
+use \Talis\Persona\Client\HttpClientFactory;
+use \Doctrine\Common\Cache\ArrayCache;
+use \Guzzle\Http\Message\Response;
+use \Guzzle\Plugin\Mock\MockPlugin;
+use \Guzzle\Http\Exception\CurlException;
+
+class HttpClientFactoryTest extends TestBase
+{
+    public function testDefaultCaching()
+    {
+        $cacheBackend = $this->getMock(
+            '\Doctrine\Common\Cache\ArrayCache',
+            ['doSave']
+        );
+
+        $lifetimes = [];
+        $cacheBackend->expects($this->exactly(2))
+            ->method('doSave')
+            ->will($this->returnCallback(function($id, $data, $lifetime) use (&$lifetimes) {
+                array_push($lifetimes, $lifetime);
+            }));
+
+        $factory = new HttpClientFactory(
+            'http://localhost',
+            $cacheBackend
+        );
+
+        $httpClient = $factory->create();
+
+        $plugin = new MockPlugin();
+        $plugin->addResponse(new Response(200, [], 'body'));
+        $httpClient->addSubscriber($plugin);
+
+        $request = $httpClient->createRequest('get', '/test/path');
+        $response = $request->send();
+
+        $this->assertEquals([3600, 0], $lifetimes);
+    }
+
+    public function testSettingKeyPrefix()
+    {
+        $cacheBackend = $this->getMock(
+            '\Doctrine\Common\Cache\ArrayCache',
+            ['doSave']
+        );
+
+        $cacheBackend->expects($this->exactly(2))
+            ->method('doSave')
+            ->will($this->returnCallback(function($id, $data, $lifetime) {
+                $this->assertTrue(strpos($id, 'prefix_') === 1);
+            }));
+
+        $factory = new HttpClientFactory(
+            'http://localhost',
+            $cacheBackend,
+            ['keyPrefix' => 'prefix_']
+        );
+
+        $httpClient = $factory->create();
+
+        $plugin = new MockPlugin();
+        $plugin->addResponse(new Response(200, [], 'body'));
+        $httpClient->addSubscriber($plugin);
+
+        $request = $httpClient->createRequest('get', '/test/path');
+        $response = $request->send();
+    }
+
+    public function testSettingTtl()
+    {
+        $cacheBackend = $this->getMock(
+            '\Doctrine\Common\Cache\ArrayCache',
+            ['doSave']
+        );
+
+        $lifetimes = [];
+        $cacheBackend->expects($this->exactly(2))
+            ->method('doSave')
+            ->will($this->returnCallback(function($id, $data, $lifetime) use (&$lifetimes) {
+                array_push($lifetimes, $lifetime);
+            }));
+
+        $factory = new HttpClientFactory(
+            'http://localhost',
+            $cacheBackend,
+            ['defaultTtl' => 300]
+        );
+
+        $httpClient = $factory->create();
+
+        $plugin = new MockPlugin();
+        $plugin->addResponse(new Response(200, [], 'body'));
+        $httpClient->addSubscriber($plugin);
+
+        $request = $httpClient->createRequest('get', '/test/path');
+        $response = $request->send();
+
+        $this->assertEquals([300, 0], $lifetimes);
+    }
+
+    public function testSecondRequestUsesCache()
+    {
+        $cacheBackend = new ArrayCache();
+
+        $factory = new HttpClientFactory(
+            'http://localhost',
+            $cacheBackend
+        );
+
+        $httpClient = $factory->create();
+        $plugin = new MockPlugin();
+        $plugin->addResponse(new Response(200, [], 'body'));
+        $httpClient->addSubscriber($plugin);
+
+        $request = $httpClient->createRequest('get', '/test/path');
+        $response = $request->send();
+
+        $httpClient = $factory->create();
+        $request = $httpClient->createRequest('get', '/test/path');
+        $response = $request->send();
+
+        $this->assertEquals('body', $response->getBody());
+    }
+}


### PR DESCRIPTION
Refactor out the creation of the http client so that tests can easily be written around the component without needing to test the base class.

This change will allow https://github.com/talis/platform/issues/1980 to test the caching mechanism when retrieving the public certificate.

part of https://github.com/talis/platform/issues/1980