### PR TITLE
Correct typehint for Tokens::listScopes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "talis/talis-php",
   "description": "This is a php client library for talis api's",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "keywords": [
     "persona",
     "echo",

--- a/src/Talis/Persona/Client/Tokens.php
+++ b/src/Talis/Persona/Client/Tokens.php
@@ -231,7 +231,7 @@ class Tokens extends Base
      *
      * @throws TokenValidationException Invalid signature, key or token
      */
-    public function listScopes($tokenInArray, $pubCertCacheTTL = 300)
+    public function listScopes(array $tokenInArray, $pubCertCacheTTL = 300)
     {
         if (!isset($tokenInArray['access_token'])) {
             throw new TokenValidationException('missing access token');

--- a/src/Talis/Persona/Client/Tokens.php
+++ b/src/Talis/Persona/Client/Tokens.php
@@ -225,21 +225,21 @@ class Tokens extends Base
 
     /**
      * List all scopes that belong to a given token
-     * @param string $token JWT token
+     * @param array $tokenInArray An array containing a JWT under the key `access_token`
      * @param integer $pubCertCacheTTL optional JWT public certificate time-to-live
      * @return array list of scopes
      *
      * @throws TokenValidationException Invalid signature, key or token
      */
-    public function listScopes($token, $pubCertCacheTTL = 300)
+    public function listScopes($tokenInArray, $pubCertCacheTTL = 300)
     {
-        if (!isset($token['access_token'])) {
+        if (!isset($tokenInArray['access_token'])) {
             throw new TokenValidationException('missing access token');
         }
 
         $publicCert = $this->retrieveJWTCertificate($pubCertCacheTTL);
 
-        $encodedToken = $token['access_token'];
+        $encodedToken = $tokenInArray['access_token'];
         $decodedToken = $this->decodeToken($encodedToken, $publicCert);
 
         if (isset($decodedToken['scopes']) && is_array($decodedToken['scopes'])) {


### PR DESCRIPTION
Correct typehint for `Tokens::listScopes` - the first argument is an array, not a string.

I don't know whether there's appetite for a breaking change, but really it doesn't make sense to wrap this up in an array - it makes the method harder to use (since you need to understand the structure of the array), and makes the signature less useful.  I'd prefer it if it *did* accept a string, but that is a breaking change.