### PR TITLE
ENT-1048: add manifesto php client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM talis/ubuntu:1404-latest
 
 ENV DEBIAN_FRONTEND noninteractive
 
-#ARG git_oauth_token
+ARG git_oauth_token
 ARG persona_oauth_client
 ARG persona_oauth_secret
 
@@ -32,7 +32,7 @@ RUN apt-get install --no-install-recommends -y \
 # Install composer
 RUN curl https://getcomposer.org/installer | php -- && mv composer.phar /usr/local/bin/composer && chmod +x /usr/local/bin/composer
 
-#RUN composer config -g github-oauth.github.com $git_oauth_token
+RUN composer config -g github-oauth.github.com $git_oauth_token
 
 # Tidy up
 RUN apt-get -y autoremove && apt-get clean && apt-get autoclean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM talis/ubuntu:1404-latest
 
 ENV DEBIAN_FRONTEND noninteractive
 
-ARG git_oauth_token
 ARG persona_oauth_client
 ARG persona_oauth_secret
 
@@ -32,7 +31,7 @@ RUN apt-get install --no-install-recommends -y \
 # Install composer
 RUN curl https://getcomposer.org/installer | php -- && mv composer.phar /usr/local/bin/composer && chmod +x /usr/local/bin/composer
 
-RUN composer config -g github-oauth.github.com $git_oauth_token
+RUN composer
 
 # Tidy up
 RUN apt-get -y autoremove && apt-get clean && apt-get autoclean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,6 @@ RUN apt-get install --no-install-recommends -y \
 # Install composer
 RUN curl https://getcomposer.org/installer | php -- && mv composer.phar /usr/local/bin/composer && chmod +x /usr/local/bin/composer
 
-RUN composer
-
 # Tidy up
 RUN apt-get -y autoremove && apt-get clean && apt-get autoclean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM talis/ubuntu:1404-latest
 
 ENV DEBIAN_FRONTEND noninteractive
 
-ARG git_oauth_token
+#ARG git_oauth_token
 ARG persona_oauth_client
 ARG persona_oauth_secret
 
@@ -32,7 +32,7 @@ RUN apt-get install --no-install-recommends -y \
 # Install composer
 RUN curl https://getcomposer.org/installer | php -- && mv composer.phar /usr/local/bin/composer && chmod +x /usr/local/bin/composer
 
-RUN composer config -g github-oauth.github.com $git_oauth_token
+#RUN composer config -g github-oauth.github.com $git_oauth_token
 
 # Tidy up
 RUN apt-get -y autoremove && apt-get clean && apt-get autoclean && \

--- a/README.md
+++ b/README.md
@@ -23,10 +23,22 @@ up and running to develop and test changes. Follow these steps:
 
 # Build the development image
 
+Clone the repo locally:
 ```bash
 git clone https://github.com/talis/talis-php.git
 cd talis-php
-ant build
+```
+
+Manually run a docker build:
+
+```bash
+docker build -t "talis/talis-php" --network=host --build-arg persona_oauth_client=<client-name-goes-here> --build-arg persona_oauth_secret=<password-goes-here> .
+```
+
+Before being able to execute any of the `docker-compose` commands you must run:
+
+```bash
+docker-compose run init
 ```
 
 # When the above has built you can run the tests

--- a/README.md
+++ b/README.md
@@ -33,8 +33,14 @@ cd talis-php
 Manually run a docker build:
 
 ```bash
-docker build -t "talis/talis-php" --network=host --build-arg persona_oauth_client=<client-name-goes-here> --build-arg persona_oauth_secret=<password-goes-here> .
+docker build -t "talis/talis-php" --network=host --build-arg git_oauth_token=<your-git-oauth-token-goes-here> --build-arg persona_oauth_client=<persona-user-goes-here> --build-arg persona_oauth_secret=<persona-secret-goes-here> .
 ```
+
+`git_oauth_token` = either generate or use an existing git_oauth token. To generate see guide here: https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line
+
+`persona_oauth_client` = the persona user you want to use.
+
+`persona_oauth_secret` =  the password to the user specified.
 
 Initialise the environment. Run the following command which will download the required libraries.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ up and running to develop and test changes. Follow these steps:
 # Build the development image
 
 Clone the repo locally:
+
 ```bash
 git clone https://github.com/talis/talis-php.git
 cd talis-php
@@ -35,13 +36,15 @@ Manually run a docker build:
 docker build -t "talis/talis-php" --network=host --build-arg persona_oauth_client=<client-name-goes-here> --build-arg persona_oauth_secret=<password-goes-here> .
 ```
 
-Before being able to execute any of the `docker-compose` commands you must run:
+Initialise the environment. Run the following command which will download the required libraries.
 
 ```bash
 docker-compose run init
 ```
 
 # When the above has built you can run the tests
+
+Available test commands:
 
 ```bash
 docker-compose run lint

--- a/README.md
+++ b/README.md
@@ -33,10 +33,8 @@ cd talis-php
 Manually run a docker build:
 
 ```bash
-docker build -t "talis/talis-php" --network=host --build-arg git_oauth_token=<your-git-oauth-token-goes-here> --build-arg persona_oauth_client=<persona-user-goes-here> --build-arg persona_oauth_secret=<persona-secret-goes-here> .
+docker build -t "talis/talis-php" --network=host --build-arg persona_oauth_client=<persona-user-goes-here> --build-arg persona_oauth_secret=<persona-secret-goes-here> .
 ```
-
-`git_oauth_token` = either generate or use an existing git_oauth token. To generate see guide here: https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line
 
 `persona_oauth_client` = the persona user you want to use.
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "talis/talis-php",
   "description": "This is a php client library for talis api's",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "keywords": [
     "persona",
     "echo",

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "echo",
     "babel",
     "critic",
+    "manifesto",
     "php",
     "client library"
   ],
@@ -35,7 +36,9 @@
       "Talis\\Critic\\": "src",
       "Talis\\Critic\\Exceptions\\": "src",
       "Talis\\EchoClient\\": "src",
-      "Talis\\Babel\\": "src"
+      "Talis\\Babel\\": "src",
+      "Talis\\Manifesto\\": "src",
+      "Talis\\Manifesto\\Exceptions": "src"
     }
   }
 }

--- a/src/Talis/Manifesto/Archive.php
+++ b/src/Talis/Manifesto/Archive.php
@@ -1,0 +1,70 @@
+<?php
+
+
+namespace Talis\Manifesto;
+
+require_once 'common.inc.php';
+
+class Archive {
+    /**
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * @var string
+     */
+    protected $status;
+
+    /**
+     * @var string
+     */
+    protected $location;
+
+    public function loadFromJson($jsonDocument)
+    {
+        $this->loadFromArray(json_decode($jsonDocument, true));
+    }
+
+    public function loadFromArray(array $array)
+    {
+        if(isset($array['id']))
+        {
+            $this->id = $array['id'];
+        }
+        if(isset($array['status']))
+        {
+            $this->status = $array['status'];
+        }
+
+        if(isset($array['location']))
+        {
+            $this->location = $array['location'];
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLocation()
+    {
+        return $this->location;
+    }
+
+    /**
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+}

--- a/src/Talis/Manifesto/Client.php
+++ b/src/Talis/Manifesto/Client.php
@@ -125,13 +125,13 @@ class Client {
 
             if($response->getStatusCode() == 202)
             {
-                $archive = new \Manifesto\Archive();
+                $archive = new \Talis\Manifesto\Archive();
                 $archive->loadFromJson($response->getBody(true));
                 return $archive;
             }
             else
             {
-                throw new \Manifesto\Exceptions\ArchiveException($response->getStatusCode(), $response->getBody(true));
+                throw new \Talis\Manifesto\Exceptions\ArchiveException($response->getStatusCode(), $response->getBody(true));
             }
         }
         /** @var \Guzzle\Http\Exception\ClientErrorResponseException $e */
@@ -188,7 +188,7 @@ class Client {
                 return $body->url;
             } else
             {
-                throw new \Manifesto\Exceptions\GenerateUrlException($response->getStatusCode, $response->getBody(true));
+                throw new \Talis\Manifesto\Exceptions\GenerateUrlException($response->getStatusCode, $response->getBody(true));
             }
 
         } catch(\Guzzle\Http\Exception\ClientErrorResponseException $e){

--- a/src/Talis/Manifesto/Client.php
+++ b/src/Talis/Manifesto/Client.php
@@ -1,0 +1,246 @@
+<?php
+
+namespace Talis\Manifesto;
+
+require_once dirname(__FILE__) . '/common.inc.php';
+
+class Client {
+
+    protected $clientId;
+    protected $clientSecret;
+
+    /**
+     * @var Talis\Persona\Client\Tokens
+     */
+    protected $personaClient;
+
+    /**
+     * @var array
+     */
+    protected $personaConnectValues = array();
+
+    /**
+     * @var string
+     */
+    protected $manifestoBaseUrl;
+
+    /**
+     * @var \Guzzle\Http\Client
+     */
+    protected $httpClient;
+    /**
+     * @param string $manifestoBaseUrl
+     * @param array $personaConnectValues
+     */
+    public function __construct($manifestoBaseUrl, $personaConnectValues = array())
+    {
+        $this->manifestoBaseUrl = $manifestoBaseUrl;
+        $this->personaConnectValues = $personaConnectValues;
+    }
+
+    /**
+     * @param array $personaConnectValues
+     */
+    public function setPersonaConnectValues($personaConnectValues)
+    {
+        $this->personaConnectValues = $personaConnectValues;
+    }
+
+    /**
+     * @return string
+     */
+    public function getManifestoBaseUrl()
+    {
+        return $this->manifestoBaseUrl;
+    }
+
+    /**
+     * @param string $manifestoBaseUrl
+     */
+    public function setManifestoBaseUrl($manifestoBaseUrl)
+    {
+        $this->manifestoBaseUrl = $manifestoBaseUrl;
+    }
+
+    /**
+     * For mocking
+     * @return Talis\Persona\Client\Tokens
+     */
+    protected function getPersonaClient()
+    {
+        if(!isset($this->personaClient))
+        {
+            $this->personaClient = new Talis\Persona\Client\Tokens($this->personaConnectValues);
+        }
+        return $this->personaClient;
+    }
+
+    /**
+     * Allows PersonaClient override, if PersonaClient has been initialized elsewhere
+     * @param Talis\Persona\Client\Tokens $personaClient
+     */
+    public function setPersonaClient(\Talis\Persona\Client\Tokens $personaClient)
+    {
+        $this->personaClient = $personaClient;
+    }
+
+    /**
+     * For mocking
+     * @return \Guzzle\Http\Client
+     */
+    protected function getHTTPClient()
+    {
+        if(!$this->httpClient)
+        {
+            $this->httpClient = new \Guzzle\Http\Client();
+        }
+        return $this->httpClient;
+    }
+
+    /**
+     * Create an archive generation job request
+     *
+     * @param Manifest $manifest
+     * @param string $clientId
+     * @param string $clientSecret
+     * @throws \Exception|\Guzzle\Http\Exception\ClientErrorResponseException
+     * @throws Exceptions\ManifestValidationException
+     * @throws Exceptions\UnauthorisedAccessException
+     * @throws Exceptions\ArchiveException
+     * @return \Talis\Manifesto\Archive
+     */
+    public function requestArchive(Manifest $manifest, $clientId, $clientSecret)
+    {
+        $archiveLocation = $this->manifestoBaseUrl . '/1/archives';
+        $manifestDocument = json_encode($manifest->generateManifest());
+
+        try
+        {
+            $client = $this->getHTTPClient();
+            $headers = $this->getHeaders($clientId, $clientSecret);
+
+            $request = $client->post($archiveLocation, $headers, $manifestDocument);
+
+            $response = $request->send();
+
+            if($response->getStatusCode() == 202)
+            {
+                $archive = new \Manifesto\Archive();
+                $archive->loadFromJson($response->getBody(true));
+                return $archive;
+            }
+            else
+            {
+                throw new \Manifesto\Exceptions\ArchiveException($response->getStatusCode(), $response->getBody(true));
+            }
+        }
+        /** @var \Guzzle\Http\Exception\ClientErrorResponseException $e */
+        catch(\Guzzle\Http\Exception\ClientErrorResponseException $e)
+        {
+            $response = $e->getResponse();
+            $error = $this->processErrorResponseBody($response->getBody(true));
+            switch($response->getStatusCode())
+            {
+                case 400:
+                    throw new \Talis\Manifesto\Exceptions\ManifestValidationException($error['message'], $error['error_code'], $e);
+                case 403:
+                case 401:
+                    throw new \Talis\Manifesto\Exceptions\UnauthorisedAccessException($error['message'], $error['error_code'], $e);
+                    break;
+                case 404:
+                    throw new \Talis\Manifesto\Exceptions\ArchiveException('Misconfigured Manifesto base url', 404);
+                    break;
+                default:
+                    throw $e;
+            }
+        }
+
+    }
+
+    /**
+     * Generate a pre signed URL via Manifesto API
+     * @param string $jobId
+     * @param string $clientId
+     * @param string $clientSecret
+     * @return string
+     * @throws \Exception|\Guzzle\Http\Exception\ClientErrorResponseException
+     * @throws Exceptions\GenerateUrlException
+     */
+    public function generateUrl($jobId, $clientId, $clientSecret)
+    {
+        $url = $this->manifestoBaseUrl . '/1/archives/'.$jobId.'/generateUrl';
+        try
+        {
+            $client = $this->getHTTPClient();
+            $headers = $this->getHeaders($clientId, $clientSecret);
+
+            $request = $client->post($url, $headers);
+
+            $response = $request->send();
+
+            if($response->getStatusCode() == 200)
+            {
+                $body = $response->getBody(true);
+                if(!empty($body))
+                {
+                    $body = json_decode($response->getBody(true));
+                }
+                return $body->url;
+            } else
+            {
+                throw new \Manifesto\Exceptions\GenerateUrlException($response->getStatusCode, $response->getBody(true));
+            }
+
+        } catch(\Guzzle\Http\Exception\ClientErrorResponseException $e){
+            $response = $e->getResponse();
+            $error = $this->processErrorResponseBody($response->getBody(true));
+            switch($response->getStatusCode())
+            {
+                case 401:
+                    throw new \Talis\Manifesto\Exceptions\UnauthorisedAccessException($error['message'], $error['error_code'], $e);
+                    break;
+                case 404:
+                    throw new \Talis\Manifesto\Exceptions\GenerateUrlException('Missing archive', 404);
+                    break;
+                default:
+                    throw $e;
+            }
+        }
+    }
+
+    /**
+     * Setup the header array for any request to Manifesto
+     * @param string $clientId
+     * @param string $clientSecret
+     * @return array
+     */
+    protected function getHeaders($clientId, $clientSecret)
+    {
+        $arrPersonaToken = $this->getPersonaClient()->obtainNewToken($clientId, $clientSecret);
+        $personaToken = $arrPersonaToken['access_token'];
+        $headers = array(
+            'Content-Type'=>'application/json',
+            'Authorization'=>'Bearer '.$personaToken
+        );
+        return $headers;
+    }
+
+    protected function processErrorResponseBody($responseBody)
+    {
+
+        $error = array('error_code'=>null, 'message'=>null);
+        $response = json_decode($responseBody, true);
+
+        if(isset($response['error_code']))
+        {
+            $error['error_code'] = $response['error_code'];
+        }
+
+        if(isset($response['message']))
+        {
+            $error['message'] = $response['message'];
+        }
+
+        return $error;
+    }
+}

--- a/src/Talis/Manifesto/Exceptions/ArchiveException.php
+++ b/src/Talis/Manifesto/Exceptions/ArchiveException.php
@@ -1,0 +1,9 @@
+<?php
+
+
+namespace Talis\Manifesto\Exceptions;
+
+
+class ArchiveException extends \Exception {
+
+}

--- a/src/Talis/Manifesto/Exceptions/ErrorResponseException.php
+++ b/src/Talis/Manifesto/Exceptions/ErrorResponseException.php
@@ -1,0 +1,19 @@
+<?php
+
+
+namespace Talis\Manifesto\Exceptions;
+
+
+class ErrorResponseException extends \Exception {
+
+    /**
+     * @param string $message [optional] Manifesto error message
+     * @param string $code [optional] Manifesto error code
+     * @param \Exception $previous [optional] The previous exception used for the exception chaining.
+     */
+    public function __construct($message = "", $code = "", \Exception $previous=null)
+    {
+        $this->code = $code;
+        parent::__construct($message, null, $previous);
+    }
+}

--- a/src/Talis/Manifesto/Exceptions/GenerateUrlException.php
+++ b/src/Talis/Manifesto/Exceptions/GenerateUrlException.php
@@ -1,0 +1,9 @@
+<?php
+
+
+namespace Talis\Manifesto\Exceptions;
+
+
+class GenerateUrlException extends \Exception {
+
+}

--- a/src/Talis/Manifesto/Exceptions/ManifestValidationException.php
+++ b/src/Talis/Manifesto/Exceptions/ManifestValidationException.php
@@ -1,0 +1,9 @@
+<?php
+
+
+namespace Talis\Manifesto\Exceptions;
+
+
+class ManifestValidationException extends ErrorResponseException {
+
+}

--- a/src/Talis/Manifesto/Exceptions/UnauthorisedAccessException.php
+++ b/src/Talis/Manifesto/Exceptions/UnauthorisedAccessException.php
@@ -1,0 +1,8 @@
+<?php
+
+
+namespace Talis\Manifesto\Exceptions;
+
+
+class UnauthorisedAccessException extends ErrorResponseException {
+}

--- a/src/Talis/Manifesto/Manifest.php
+++ b/src/Talis/Manifesto/Manifest.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Talis\Manifesto;
+
+require_once dirname(__FILE__) . '/common.inc.php';
+
+class Manifest
+{
+
+    protected $callbackLocation;
+    protected $callbackMethod = 'GET';
+    protected $fileCount;
+    protected $files = array();
+    protected $format;
+    protected $safeMode = false;
+
+    protected $validFormats = array(FORMAT_ZIP, FORMAT_TARGZ, FORMAT_TARBZ);
+
+    public function __construct($safeMode = false)
+    {
+        $this->safeMode = $safeMode;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getSafeMode()
+    {
+        return $this->safeMode;
+    }
+
+    /**
+     * @param boolean $safeMode
+     */
+    public function setSafeMode($safeMode)
+    {
+        $this->safeMode = $safeMode;
+    }
+
+    /**
+     * @return int
+     */
+    public function getFileCount()
+    {
+        return $this->fileCount;
+    }
+
+    /**
+     * @param int $fileCount
+     */
+    public function setFileCount($fileCount)
+    {
+        $this->fileCount = $fileCount;
+    }
+
+    /**
+     * @return array
+     * @throws Exceptions\ManifestValidationException
+     */
+    public function generateManifest()
+    {
+        if(empty($this->files))
+        {
+            throw new \Talis\Manifesto\Exceptions\ManifestValidationException("No files have been added to manifest");
+        }
+
+        if(!in_array($this->format, $this->validFormats))
+        {
+            throw new \Talis\Manifesto\Exceptions\ManifestValidationException("Output format has not been set");
+        }
+
+        if($this->safeMode && (!isset($this->fileCount) || empty($this->fileCount)))
+        {
+            throw new \Talis\Manifesto\Exceptions\ManifestValidationException("File count must be set in safe mode");
+        }
+        elseif(!($this->safeMode && isset($this->fileCount)))
+        {
+            $this->fileCount = count($this->files);
+        }
+
+        if($this->fileCount != count($this->files))
+        {
+            throw new \Talis\Manifesto\Exceptions\ManifestValidationException("Number of files does not equal fileCount");
+        }
+
+        $manifest = array();
+        if(isset($this->callbackLocation))
+        {
+            $manifest['callback'] = array('url'=>$this->callbackLocation, 'method'=>$this->callbackMethod);
+        }
+
+        $manifest['format'] = $this->format;
+
+        $manifest['fileCount'] = $this->fileCount;
+
+        $manifest['files'] = $this->files;
+
+        return $manifest;
+    }
+
+    /**
+     * @return array
+     */
+    public function getFiles()
+    {
+        return $this->files;
+    }
+
+    /**
+     * @param array $file
+     * @throws \InvalidArgumentException
+     */
+    public function addFile(array $file)
+    {
+        if(!array_key_exists('file', $file) || empty($file['file']))
+        {
+            throw new \InvalidArgumentException("Files must contain a file key and value");
+        }
+
+        if(array_key_exists('type', $file) && !in_array($file['type'], array(FILE_TYPE_S3, FILE_TYPE_CF)))
+        {
+            throw new \InvalidArgumentException("Unsupported file 'type'");
+        }
+        $this->files[] = $file;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getFormat()
+    {
+        return $this->format;
+    }
+
+    /**
+     * @param string $format
+     * @throws \InvalidArgumentException
+     */
+    public function setFormat($format)
+    {
+        if(!in_array($format, $this->validFormats))
+        {
+            throw new \InvalidArgumentException("'{$format}' is not supported");
+        }
+        $this->format = $format;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getCallbackLocation()
+    {
+        return $this->callbackLocation;
+    }
+
+    /**
+     * @param mixed $callbackLocation
+     * @throws \InvalidArgumentException
+     */
+    public function setCallbackLocation($callbackLocation)
+    {
+        if(!(filter_var($callbackLocation, FILTER_VALIDATE_URL) && preg_match("/^https?:\/\//", $callbackLocation)))
+        {
+            throw new \InvalidArgumentException("Callback location must be an http or https url");
+        }
+        $this->callbackLocation = $callbackLocation;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCallbackMethod()
+    {
+        return $this->callbackMethod;
+    }
+
+    /**
+     * @param string $callbackMethod
+     * @throws \InvalidArgumentException
+     */
+    public function setCallbackMethod($callbackMethod)
+    {
+        if(!in_array(strtoupper($callbackMethod), array("GET", "POST")))
+        {
+            throw new \InvalidArgumentException("Callback method must be GET or POST");
+        }
+        $this->callbackMethod = strtoupper($callbackMethod);
+    }
+
+}

--- a/src/Talis/Manifesto/common.inc.php
+++ b/src/Talis/Manifesto/common.inc.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Talis\Manifesto;
+
+define('FORMAT_ZIP', 'zip');
+define('FORMAT_TARGZ', 'targz');
+define('FORMAT_TARBZ', 'tarbz');
+
+define('FILE_TYPE_S3', 'amazon');
+define('FILE_TYPE_CF', 'rackspace');

--- a/test/unit/Manifesto/ArchiveTest.php
+++ b/test/unit/Manifesto/ArchiveTest.php
@@ -1,0 +1,30 @@
+<?php
+
+require_once '../TestBase.php';
+
+class ArchiveTest extends TestBase
+{
+    public function testLoadFromArray()
+    {
+        $response = array('status'=>'Completed', 'location'=>'http://example.com/1234', 'id'=>"1234");
+
+        $archive = new \Manifesto\Archive();
+        $archive->loadFromArray($response);
+
+        $this->assertEquals("1234", $archive->getId());
+        $this->assertEquals('Completed', $archive->getStatus());
+        $this->assertEquals('http://example.com/1234', $archive->getLocation());
+    }
+
+    public function testLoadFromJSON()
+    {
+        $response = "{\"status\":\"Completed\", \"location\":\"http:\/\/example.com\/1234\", \"id\":\"1234\"}";
+
+        $archive = new \Manifesto\Archive();
+        $archive->loadFromJson($response);
+
+        $this->assertEquals("1234", $archive->getId());
+        $this->assertEquals('Completed', $archive->getStatus());
+        $this->assertEquals('http://example.com/1234', $archive->getLocation());
+    }
+}

--- a/test/unit/Manifesto/ArchiveTest.php
+++ b/test/unit/Manifesto/ArchiveTest.php
@@ -13,7 +13,7 @@ class ArchiveTest extends TestBase
     {
         $response = array('status'=>'Completed', 'location'=>'http://example.com/1234', 'id'=>"1234");
 
-        $archive = new \Manifesto\Archive();
+        $archive = new \Talis\Manifesto\Archive();
         $archive->loadFromArray($response);
 
         $this->assertEquals("1234", $archive->getId());
@@ -25,7 +25,7 @@ class ArchiveTest extends TestBase
     {
         $response = "{\"status\":\"Completed\", \"location\":\"http:\/\/example.com\/1234\", \"id\":\"1234\"}";
 
-        $archive = new \Manifesto\Archive();
+        $archive = new \Talis\Manifesto\Archive();
         $archive->loadFromJson($response);
 
         $this->assertEquals("1234", $archive->getId());

--- a/test/unit/Manifesto/ArchiveTest.php
+++ b/test/unit/Manifesto/ArchiveTest.php
@@ -1,6 +1,11 @@
 <?php
 
-require_once '../TestBase.php';
+$appRoot = dirname(dirname(dirname(__DIR__)));
+if (!defined('APPROOT')) {
+    define('APPROOT', $appRoot);
+}
+
+require_once $appRoot . '/test/unit/TestBase.php';
 
 class ArchiveTest extends TestBase
 {

--- a/test/unit/Manifesto/ClientTest.php
+++ b/test/unit/Manifesto/ClientTest.php
@@ -1,0 +1,613 @@
+<?php
+
+require_once 'TestBase.php';
+
+class ClientTest extends TestBase
+{
+    public function testSetGetManifestoBaseUrl()
+    {
+        $baseUrl = 'http://example.com/manifesto';
+        $client = new \Manifesto\Client($baseUrl);
+        $this->assertEquals($baseUrl, $client->getManifestoBaseUrl());
+        $client->setManifestoBaseUrl('https://example.org/foobar');
+        $this->assertEquals('https://example.org/foobar', $client->getManifestoBaseUrl());
+    }
+
+    public function testSetGetPersonaConnectValues()
+    {
+        $client = new TestManifestoClient('http://example.com/');
+        $this->assertEmpty($client->getPersonaConnectValues());
+
+        $cacheDriver = new \Doctrine\Common\Cache\ArrayCache();
+        $personaOpts = array(
+            'persona_host' => 'http://persona',
+            'persona_oauth_route' => '/oauth/tokens/',
+            'userAgent' => 'manifesto-client/1.0',
+            'cacheBackend' =>  $cacheDriver,
+        );
+
+        $client->setPersonaConnectValues($personaOpts);
+        $this->assertEquals($personaOpts, $client->getPersonaConnectValues());
+
+        // Test that passing opts in constructor also sets property
+        $client = new TestManifestoClient('https://example.org/', $personaOpts);
+        // Make sure that we're actually looking at the right thing, since assertions are cheap
+        $this->assertEquals('https://example.org/', $client->getManifestoBaseUrl());
+        $this->assertEquals($personaOpts, $client->getPersonaConnectValues());
+    }
+
+    public function testSetPersonaClient()
+    {
+        $client = new TestManifestoClient('http://example.com/');
+        $cacheDriver = new \Doctrine\Common\Cache\ArrayCache();
+        $persona = new Talis\Persona\Client\Tokens(
+            array(
+                'persona_host' => 'http://persona',
+                'persona_oauth_route' => '/oauth/tokens/',
+                'userAgent' => 'manifesto-client/1.0',
+                'cacheBackend' =>  $cacheDriver,
+            )
+        );
+
+        $client->setPersonaClient($persona);
+        $this->assertEquals($persona, $client->getPersonaClient());
+    }
+
+    public function testSuccessfulRequestArchive()
+    {
+        /** @var \Manifesto\Client|PHPUnit_Framework_MockObject_MockObject $mockClient */
+        $mockClient = $this->getMock(
+            '\Manifesto\Client',
+            array('getHeaders', 'getHTTPClient'),
+            array('https://example.com/manifesto')
+        );
+
+        $mockClient->expects($this->once())
+            ->method('getHeaders')
+            ->will(
+                $this->returnValue(array(
+                    array(
+                        'Content-Type'=>'application/json',
+                        'Authorization'=>'Bearer FooToken'
+                    )
+                ))
+            );
+
+        $client = new \Guzzle\Http\Client('https://example.com/manifesto');
+        $plugin = new \Guzzle\Plugin\Mock\MockPlugin();
+        $plugin->addResponse(
+            new \Guzzle\Http\Message\Response(
+                202,
+                null,
+                json_encode(array('id'=>"12345", "status"=>"Accepted"))
+                ));
+        $client->addSubscriber($plugin);
+
+        $mockClient->expects($this->once())
+            ->method('getHTTPClient')
+            ->will($this->returnValue($client));
+
+        // Set this manually since it won't work from the constructor since we're mocking
+        $mockClient->setManifestoBaseUrl('https://example.com/manifesto');
+
+        $cacheDriver = new \Doctrine\Common\Cache\ArrayCache();
+        $personaOpts = array(
+            'persona_host' => 'http://persona',
+            'persona_oauth_route' => '/oauth/tokens/',
+            'userAgent' => 'manifesto-client/1.0',
+            'cacheBackend' =>  $cacheDriver,
+        );
+
+        $mockClient->setPersonaConnectValues($personaOpts);
+
+        $m = new \Manifesto\Manifest();
+        $m->setFormat(FORMAT_ZIP);
+        $files = array();
+        $file1 = array('file'=>'/path/to/file1.txt');
+        $files[] = $file1;
+        $m->addFile($file1);
+
+        $file2 = array('type'=>FILE_TYPE_S3, 'container'=>'myBucket', 'file'=>'/path/to/file2.txt', 'destinationPath'=>'foobar.txt');
+        $files[] = $file2;
+        $m->addFile($file2);
+
+        $file3 = array('type'=>FILE_TYPE_CF, 'file'=>'/path/to/file3.txt', 'destinationPath'=>'/another/path/foobar.txt');
+        $files[] = $file3;
+        $m->addFile($file3);
+
+        /** @var \Manifesto\Archive $response */
+        $response = $mockClient->requestArchive($m, 'token', 'secret');
+
+        $this->assertInstanceOf('\Manifesto\Archive', $response);
+        $this->assertEquals('12345', $response->getId());
+        $this->assertEquals('Accepted', $response->getStatus());
+        $this->assertEmpty($response->getLocation());
+    }
+
+    public function testGenerateUrlNotAuthorisedResponse()
+    {
+        /** @var \Manifesto\Client|PHPUnit_Framework_MockObject_MockObject $mockClient */
+        $mockClient = $this->getMock(
+            '\Manifesto\Client',
+            array('getHeaders', 'getHTTPClient'),
+            array('https://example.com/manifesto')
+        );
+
+        $mockClient->expects($this->once())
+            ->method('getHeaders')
+            ->will(
+                $this->returnValue(array(
+                    array(
+                        'Content-Type' => 'application/json',
+                        'Authorization' => 'Bearer FooToken'
+                    )
+                ))
+            );
+
+        $client = new \Guzzle\Http\Client('https://example.com/manifesto');
+        $plugin = new \Guzzle\Plugin\Mock\MockPlugin();
+        $plugin->addResponse(
+            new \Guzzle\Http\Message\Response(
+                401,
+                null,
+                json_encode(array('code'=>'Unauthorised request', 'message'=>'Client is not authorised for request'))
+            ));
+
+        $client->addSubscriber($plugin);
+
+        $mockClient->expects($this->once())
+            ->method('getHTTPClient')
+            ->will($this->returnValue($client));
+
+        $cacheDriver = new \Doctrine\Common\Cache\ArrayCache();
+        $personaOpts = array(
+            'persona_host' => 'http://persona',
+            'persona_oauth_route' => '/oauth/tokens/',
+            'userAgent' => 'manifesto-client/1.0',
+            'cacheBackend' =>  $cacheDriver,
+        );
+
+        $mockClient->setPersonaConnectValues($personaOpts);
+
+        $this->setExpectedException('\Manifesto\Exceptions\UnauthorisedAccessException', 'Client is not authorised for request');
+        $response = $mockClient->generateUrl('123', 'token', 'secret');
+    }
+
+    public function testGenerateUrlReturns404()
+    {
+        /** @var \Manifesto\Client|PHPUnit_Framework_MockObject_MockObject $mockClient */
+        $mockClient = $this->getMock(
+            '\Manifesto\Client',
+            array('getHeaders', 'getHTTPClient'),
+            array('https://example.com/manifesto')
+        );
+
+        $mockClient->expects($this->once())
+            ->method('getHeaders')
+            ->will(
+                $this->returnValue(array(
+                    array(
+                        'Content-Type'=>'application/json',
+                        'Authorization'=>'Bearer FooToken'
+                    )
+                ))
+            );
+
+        $client = new \Guzzle\Http\Client('https://example.com/manifesto');
+        $plugin = new \Guzzle\Plugin\Mock\MockPlugin();
+        $plugin->addResponse(
+            new \Guzzle\Http\Message\Response(
+                404,
+                null,
+                "File not found"
+            ));
+        $client->addSubscriber($plugin);
+
+        $mockClient->expects($this->once())
+            ->method('getHTTPClient')
+            ->will($this->returnValue($client));
+
+        $cacheDriver = new \Doctrine\Common\Cache\ArrayCache();
+        $personaOpts = array(
+            'persona_host' => 'http://persona',
+            'persona_oauth_route' => '/oauth/tokens/',
+            'userAgent' => 'manifesto-client/1.0',
+            'cacheBackend' =>  $cacheDriver,
+        );
+
+        $mockClient->setPersonaConnectValues($personaOpts);
+
+        $this->setExpectedException('\Manifesto\Exceptions\GenerateUrlException', 'Missing archive');
+        $response = $mockClient->generateUrl('1234', 'token', 'secret');
+    }
+
+    public function testGenerateUrlJobReadyForDownload()
+    {
+        /** @var \Manifesto\Client|PHPUnit_Framework_MockObject_MockObject $mockClient */
+        $mockClient = $this->getMock(
+            '\Manifesto\Client',
+            array('getHeaders', 'getHTTPClient'),
+            array('https://example.com/manifesto')
+        );
+
+        $mockClient->expects($this->once())
+            ->method('getHeaders')
+            ->will(
+                $this->returnValue(array(
+                    array(
+                        'Content-Type'=>'application/json',
+                        'Authorization'=>'Bearer FooToken'
+                    )
+                ))
+            );
+
+        $client = new \Guzzle\Http\Client('https://example.com/manifesto');
+        $plugin = new \Guzzle\Plugin\Mock\MockPlugin();
+        $plugin->addResponse(
+            new \Guzzle\Http\Message\Response(
+                200,
+                null,
+                json_encode(array('url'=>'https://path.to.s3/export.zip'))
+            ));
+        $client->addSubscriber($plugin);
+
+        $mockClient->expects($this->once())
+            ->method('getHTTPClient')
+            ->will($this->returnValue($client));
+
+        $cacheDriver = new \Doctrine\Common\Cache\ArrayCache();
+        $personaOpts = array(
+            'persona_host' => 'http://persona',
+            'persona_oauth_route' => '/oauth/tokens/',
+            'userAgent' => 'manifesto-client/1.0',
+            'cacheBackend' =>  $cacheDriver,
+        );
+
+        $mockClient->setPersonaConnectValues($personaOpts);
+
+        $this->assertEquals('https://path.to.s3/export.zip', $mockClient->generateUrl('1234', 'token', 'secret'));
+    }
+
+    public function testRequestArchiveNotAuthorisedResponse()
+    {
+        /** @var \Manifesto\Client|PHPUnit_Framework_MockObject_MockObject $mockClient */
+        $mockClient = $this->getMock(
+            '\Manifesto\Client',
+            array('getHeaders', 'getHTTPClient'),
+            array('https://example.com/manifesto')
+        );
+
+        $mockClient->expects($this->once())
+            ->method('getHeaders')
+            ->will(
+                $this->returnValue(array(
+                    array(
+                        'Content-Type'=>'application/json',
+                        'Authorization'=>'Bearer FooToken'
+                    )
+                ))
+            );
+
+        $client = new \Guzzle\Http\Client('https://example.com/manifesto');
+        $plugin = new \Guzzle\Plugin\Mock\MockPlugin();
+        $plugin->addResponse(
+            new \Guzzle\Http\Message\Response(
+                401,
+                null,
+                json_encode(array('code'=>'Unauthorised request', 'message'=>'Client is not authorised for request'))
+            ));
+        $client->addSubscriber($plugin);
+
+        $mockClient->expects($this->once())
+            ->method('getHTTPClient')
+            ->will($this->returnValue($client));
+
+        // Set this manually since it won't work from the constructor since we're mocking
+        $mockClient->setManifestoBaseUrl('https://example.com/manifesto');
+
+        $cacheDriver = new \Doctrine\Common\Cache\ArrayCache();
+        $personaOpts = array(
+            'persona_host' => 'http://persona',
+            'persona_oauth_route' => '/oauth/tokens/',
+            'userAgent' => 'manifesto-client/1.0',
+            'cacheBackend' =>  $cacheDriver,
+        );
+
+        $mockClient->setPersonaConnectValues($personaOpts);
+
+        $m = new \Manifesto\Manifest();
+        $m->setFormat(FORMAT_ZIP);
+        $files = array();
+        $file1 = array('file'=>'/path/to/file1.txt');
+        $files[] = $file1;
+        $m->addFile($file1);
+
+        $file2 = array('type'=>FILE_TYPE_S3, 'container'=>'myBucket', 'file'=>'/path/to/file2.txt', 'destinationPath'=>'foobar.txt');
+        $files[] = $file2;
+        $m->addFile($file2);
+
+        $file3 = array('type'=>FILE_TYPE_CF, 'file'=>'/path/to/file3.txt', 'destinationPath'=>'/another/path/foobar.txt');
+        $files[] = $file3;
+        $m->addFile($file3);
+
+        $this->setExpectedException('\Manifesto\Exceptions\UnauthorisedAccessException', 'Client is not authorised for request');
+        $response = $mockClient->requestArchive($m, 'token', 'secret');
+    }
+
+    public function testRequestArchiveInvalidManifestResponse()
+    {
+        /** @var \Manifesto\Client|PHPUnit_Framework_MockObject_MockObject $mockClient */
+        $mockClient = $this->getMock(
+            '\Manifesto\Client',
+            array('getHeaders', 'getHTTPClient'),
+            array('https://example.com/manifesto')
+        );
+
+        $mockClient->expects($this->once())
+            ->method('getHeaders')
+            ->will(
+                $this->returnValue(array(
+                    array(
+                        'Content-Type'=>'application/json',
+                        'Authorization'=>'Bearer FooToken'
+                    )
+                ))
+            );
+
+        $client = new \Guzzle\Http\Client('https://example.com/manifesto');
+        $plugin = new \Guzzle\Plugin\Mock\MockPlugin();
+        $plugin->addResponse(
+            new \Guzzle\Http\Message\Response(
+                400,
+                null,
+                json_encode(array('code'=>'Invalid Manifest', 'message'=>'The Manifest is incomplete or contains invalid properties'))
+            ));
+        $client->addSubscriber($plugin);
+
+        $mockClient->expects($this->once())
+            ->method('getHTTPClient')
+            ->will($this->returnValue($client));
+
+        // Set this manually since it won't work from the constructor since we're mocking
+        $mockClient->setManifestoBaseUrl('https://example.com/manifesto');
+
+        $cacheDriver = new \Doctrine\Common\Cache\ArrayCache();
+        $personaOpts = array(
+            'persona_host' => 'http://persona',
+            'persona_oauth_route' => '/oauth/tokens/',
+            'userAgent' => 'manifesto-client/1.0',
+            'cacheBackend' =>  $cacheDriver,
+        );
+
+        $mockClient->setPersonaConnectValues($personaOpts);
+
+        $m = new \Manifesto\Manifest();
+        $m->setFormat(FORMAT_ZIP);
+        $files = array();
+        $file1 = array('file'=>'/path/to/file1.txt');
+        $files[] = $file1;
+        $m->addFile($file1);
+
+        $file2 = array('type'=>FILE_TYPE_S3, 'container'=>'myBucket', 'file'=>'/path/to/file2.txt', 'destinationPath'=>'foobar.txt');
+        $files[] = $file2;
+        $m->addFile($file2);
+
+        $file3 = array('type'=>FILE_TYPE_CF, 'file'=>'/path/to/file3.txt', 'destinationPath'=>'/another/path/foobar.txt');
+        $files[] = $file3;
+        $m->addFile($file3);
+
+        $this->setExpectedException('\Manifesto\Exceptions\ManifestValidationException', 'The Manifest is incomplete or contains invalid properties');
+        $response = $mockClient->requestArchive($m, 'token', 'secret');
+    }
+
+    public function testRequestArchiveReturns404()
+    {
+        /** @var \Manifesto\Client|PHPUnit_Framework_MockObject_MockObject $mockClient */
+        $mockClient = $this->getMock(
+            '\Manifesto\Client',
+            array('getHeaders', 'getHTTPClient'),
+            array('https://example.com/manifesto')
+        );
+
+        $mockClient->expects($this->once())
+            ->method('getHeaders')
+            ->will(
+                $this->returnValue(array(
+                    array(
+                        'Content-Type'=>'application/json',
+                        'Authorization'=>'Bearer FooToken'
+                    )
+                ))
+            );
+
+        $client = new \Guzzle\Http\Client('https://example.com/manifesto');
+        $plugin = new \Guzzle\Plugin\Mock\MockPlugin();
+        $plugin->addResponse(
+            new \Guzzle\Http\Message\Response(
+                404,
+                null,
+                "File not found"
+            ));
+        $client->addSubscriber($plugin);
+
+        $mockClient->expects($this->once())
+            ->method('getHTTPClient')
+            ->will($this->returnValue($client));
+
+        // Set this manually since it won't work from the constructor since we're mocking
+        $mockClient->setManifestoBaseUrl('https://example.com/manifesto');
+
+        $cacheDriver = new \Doctrine\Common\Cache\ArrayCache();
+        $personaOpts = array(
+            'persona_host' => 'http://persona',
+            'persona_oauth_route' => '/oauth/tokens/',
+            'userAgent' => 'manifesto-client/1.0',
+            'cacheBackend' =>  $cacheDriver,
+        );
+
+        $mockClient->setPersonaConnectValues($personaOpts);
+
+        $m = new \Manifesto\Manifest();
+        $m->setFormat(FORMAT_ZIP);
+        $files = array();
+        $file1 = array('file'=>'/path/to/file1.txt');
+        $files[] = $file1;
+        $m->addFile($file1);
+
+        $file2 = array('type'=>FILE_TYPE_S3, 'container'=>'myBucket', 'file'=>'/path/to/file2.txt', 'destinationPath'=>'foobar.txt');
+        $files[] = $file2;
+        $m->addFile($file2);
+
+        $file3 = array('type'=>FILE_TYPE_CF, 'file'=>'/path/to/file3.txt', 'destinationPath'=>'/another/path/foobar.txt');
+        $files[] = $file3;
+        $m->addFile($file3);
+
+        $this->setExpectedException('\Manifesto\Exceptions\ArchiveException', 'Misconfigured Manifesto base url');
+        $response = $mockClient->requestArchive($m, 'token', 'secret');
+    }
+
+    public function testRequestArchiveUnexpectedClientErrorResponse()
+    {
+        /** @var \Manifesto\Client|PHPUnit_Framework_MockObject_MockObject $mockClient */
+        $mockClient = $this->getMock(
+            '\Manifesto\Client',
+            array('getHeaders', 'getHTTPClient'),
+            array('https://example.com/manifesto')
+        );
+
+        $mockClient->expects($this->once())
+            ->method('getHeaders')
+            ->will(
+                $this->returnValue(array(
+                    array(
+                        'Content-Type'=>'application/json',
+                        'Authorization'=>'Bearer FooToken'
+                    )
+                ))
+            );
+
+        $client = new \Guzzle\Http\Client('https://example.com/manifesto');
+        $plugin = new \Guzzle\Plugin\Mock\MockPlugin();
+        $plugin->addResponse(
+            new \Guzzle\Http\Message\Response(
+                420,
+                null,
+                "Enhance Your Calm"
+            ));
+        $client->addSubscriber($plugin);
+
+        $mockClient->expects($this->once())
+            ->method('getHTTPClient')
+            ->will($this->returnValue($client));
+
+        // Set this manually since it won't work from the constructor since we're mocking
+        $mockClient->setManifestoBaseUrl('https://example.com/manifesto');
+
+        $cacheDriver = new \Doctrine\Common\Cache\ArrayCache();
+        $personaOpts = array(
+            'persona_host' => 'http://persona',
+            'persona_oauth_route' => '/oauth/tokens/',
+            'userAgent' => 'manifesto-client/1.0',
+            'cacheBackend' =>  $cacheDriver,
+        );
+
+        $mockClient->setPersonaConnectValues($personaOpts);
+
+        $m = new \Manifesto\Manifest();
+        $m->setFormat(FORMAT_ZIP);
+        $files = array();
+        $file1 = array('file'=>'/path/to/file1.txt');
+        $files[] = $file1;
+        $m->addFile($file1);
+
+        $file2 = array('type'=>FILE_TYPE_S3, 'container'=>'myBucket', 'file'=>'/path/to/file2.txt', 'destinationPath'=>'foobar.txt');
+        $files[] = $file2;
+        $m->addFile($file2);
+
+        $file3 = array('type'=>FILE_TYPE_CF, 'file'=>'/path/to/file3.txt', 'destinationPath'=>'/another/path/foobar.txt');
+        $files[] = $file3;
+        $m->addFile($file3);
+
+        $this->setExpectedException('\Guzzle\Http\Exception\ClientErrorResponseException');
+        $response = $mockClient->requestArchive($m, 'token', 'secret');
+    }
+
+    public function testRequestArchiveUnexpectedServerErrorResponse()
+    {
+        /** @var \Manifesto\Client|PHPUnit_Framework_MockObject_MockObject $mockClient */
+        $mockClient = $this->getMock(
+            '\Manifesto\Client',
+            array('getHeaders', 'getHTTPClient'),
+            array('https://example.com/manifesto')
+        );
+
+        $mockClient->expects($this->once())
+            ->method('getHeaders')
+            ->will(
+                $this->returnValue(array(
+                    array(
+                        'Content-Type'=>'application/json',
+                        'Authorization'=>'Bearer FooToken'
+                    )
+                ))
+            );
+
+        $client = new \Guzzle\Http\Client('https://example.com/manifesto');
+        $plugin = new \Guzzle\Plugin\Mock\MockPlugin();
+        $plugin->addResponse(
+            new \Guzzle\Http\Message\Response(
+                500,
+                null,
+                "Server error"
+            ));
+        $client->addSubscriber($plugin);
+
+        $mockClient->expects($this->once())
+            ->method('getHTTPClient')
+            ->will($this->returnValue($client));
+
+        // Set this manually since it won't work from the constructor since we're mocking
+        $mockClient->setManifestoBaseUrl('https://example.com/manifesto');
+
+        $cacheDriver = new \Doctrine\Common\Cache\ArrayCache();
+        $personaOpts = array(
+            'persona_host' => 'http://persona',
+            'persona_oauth_route' => '/oauth/tokens/',
+            'userAgent' => 'manifesto-client/1.0',
+            'cacheBackend' =>  $cacheDriver,
+        );
+
+        $mockClient->setPersonaConnectValues($personaOpts);
+
+        $m = new \Manifesto\Manifest();
+        $m->setFormat(FORMAT_ZIP);
+        $files = array();
+        $file1 = array('file'=>'/path/to/file1.txt');
+        $files[] = $file1;
+        $m->addFile($file1);
+
+        $file2 = array('type'=>FILE_TYPE_S3, 'container'=>'myBucket', 'file'=>'/path/to/file2.txt', 'destinationPath'=>'foobar.txt');
+        $files[] = $file2;
+        $m->addFile($file2);
+
+        $file3 = array('type'=>FILE_TYPE_CF, 'file'=>'/path/to/file3.txt', 'destinationPath'=>'/another/path/foobar.txt');
+        $files[] = $file3;
+        $m->addFile($file3);
+
+        $this->setExpectedException('\Guzzle\Http\Exception\ServerErrorResponseException');
+        $response = $mockClient->requestArchive($m, 'token', 'secret');
+    }
+}
+
+class TestManifestoClient extends \Manifesto\Client
+{
+    public function getPersonaConnectValues()
+    {
+        return $this->personaConnectValues;
+    }
+
+    public function getPersonaClient()
+    {
+        return parent::getPersonaClient();
+    }
+}

--- a/test/unit/Manifesto/ClientTest.php
+++ b/test/unit/Manifesto/ClientTest.php
@@ -12,7 +12,7 @@ class ClientTest extends TestBase
     public function testSetGetManifestoBaseUrl()
     {
         $baseUrl = 'http://example.com/manifesto';
-        $client = new \Manifesto\Client($baseUrl);
+        $client = new \Talis\Manifesto\Client($baseUrl);
         $this->assertEquals($baseUrl, $client->getManifestoBaseUrl());
         $client->setManifestoBaseUrl('https://example.org/foobar');
         $this->assertEquals('https://example.org/foobar', $client->getManifestoBaseUrl());
@@ -60,9 +60,9 @@ class ClientTest extends TestBase
 
     public function testSuccessfulRequestArchive()
     {
-        /** @var \Manifesto\Client|PHPUnit_Framework_MockObject_MockObject $mockClient */
+        /** @var \Talis\Manifesto\Client|PHPUnit_Framework_MockObject_MockObject $mockClient */
         $mockClient = $this->getMock(
-            '\Manifesto\Client',
+            '\Talis\Manifesto\Client',
             array('getHeaders', 'getHTTPClient'),
             array('https://example.com/manifesto')
         );
@@ -105,7 +105,7 @@ class ClientTest extends TestBase
 
         $mockClient->setPersonaConnectValues($personaOpts);
 
-        $m = new \Manifesto\Manifest();
+        $m = new \Talis\Manifesto\Manifest();
         $m->setFormat(FORMAT_ZIP);
         $files = array();
         $file1 = array('file'=>'/path/to/file1.txt');
@@ -120,10 +120,10 @@ class ClientTest extends TestBase
         $files[] = $file3;
         $m->addFile($file3);
 
-        /** @var \Manifesto\Archive $response */
+        /** @var \Talis\Manifesto\Archive $response */
         $response = $mockClient->requestArchive($m, 'token', 'secret');
 
-        $this->assertInstanceOf('\Manifesto\Archive', $response);
+        $this->assertInstanceOf('\Talis\Manifesto\Archive', $response);
         $this->assertEquals('12345', $response->getId());
         $this->assertEquals('Accepted', $response->getStatus());
         $this->assertEmpty($response->getLocation());
@@ -131,9 +131,9 @@ class ClientTest extends TestBase
 
     public function testGenerateUrlNotAuthorisedResponse()
     {
-        /** @var \Manifesto\Client|PHPUnit_Framework_MockObject_MockObject $mockClient */
+        /** @var \Talis\Manifesto\Client|PHPUnit_Framework_MockObject_MockObject $mockClient */
         $mockClient = $this->getMock(
-            '\Manifesto\Client',
+            '\Talis\Manifesto\Client',
             array('getHeaders', 'getHTTPClient'),
             array('https://example.com/manifesto')
         );
@@ -174,15 +174,15 @@ class ClientTest extends TestBase
 
         $mockClient->setPersonaConnectValues($personaOpts);
 
-        $this->setExpectedException('\Manifesto\Exceptions\UnauthorisedAccessException', 'Client is not authorised for request');
+        $this->setExpectedException('\Talis\Manifesto\Exceptions\UnauthorisedAccessException', 'Client is not authorised for request');
         $response = $mockClient->generateUrl('123', 'token', 'secret');
     }
 
     public function testGenerateUrlReturns404()
     {
-        /** @var \Manifesto\Client|PHPUnit_Framework_MockObject_MockObject $mockClient */
+        /** @var \Talis\Manifesto\Client|PHPUnit_Framework_MockObject_MockObject $mockClient */
         $mockClient = $this->getMock(
-            '\Manifesto\Client',
+            '\Talis\Manifesto\Client',
             array('getHeaders', 'getHTTPClient'),
             array('https://example.com/manifesto')
         );
@@ -222,15 +222,15 @@ class ClientTest extends TestBase
 
         $mockClient->setPersonaConnectValues($personaOpts);
 
-        $this->setExpectedException('\Manifesto\Exceptions\GenerateUrlException', 'Missing archive');
+        $this->setExpectedException('\Talis\Manifesto\Exceptions\GenerateUrlException', 'Missing archive');
         $response = $mockClient->generateUrl('1234', 'token', 'secret');
     }
 
     public function testGenerateUrlJobReadyForDownload()
     {
-        /** @var \Manifesto\Client|PHPUnit_Framework_MockObject_MockObject $mockClient */
+        /** @var \Talis\Manifesto\Client|PHPUnit_Framework_MockObject_MockObject $mockClient */
         $mockClient = $this->getMock(
-            '\Manifesto\Client',
+            '\Talis\Manifesto\Client',
             array('getHeaders', 'getHTTPClient'),
             array('https://example.com/manifesto')
         );
@@ -275,9 +275,9 @@ class ClientTest extends TestBase
 
     public function testRequestArchiveNotAuthorisedResponse()
     {
-        /** @var \Manifesto\Client|PHPUnit_Framework_MockObject_MockObject $mockClient */
+        /** @var \Talis\Manifesto\Client|PHPUnit_Framework_MockObject_MockObject $mockClient */
         $mockClient = $this->getMock(
-            '\Manifesto\Client',
+            '\Talis\Manifesto\Client',
             array('getHeaders', 'getHTTPClient'),
             array('https://example.com/manifesto')
         );
@@ -320,7 +320,7 @@ class ClientTest extends TestBase
 
         $mockClient->setPersonaConnectValues($personaOpts);
 
-        $m = new \Manifesto\Manifest();
+        $m = new \Talis\Manifesto\Manifest();
         $m->setFormat(FORMAT_ZIP);
         $files = array();
         $file1 = array('file'=>'/path/to/file1.txt');
@@ -335,15 +335,15 @@ class ClientTest extends TestBase
         $files[] = $file3;
         $m->addFile($file3);
 
-        $this->setExpectedException('\Manifesto\Exceptions\UnauthorisedAccessException', 'Client is not authorised for request');
+        $this->setExpectedException('\Talis\Manifesto\Exceptions\UnauthorisedAccessException', 'Client is not authorised for request');
         $response = $mockClient->requestArchive($m, 'token', 'secret');
     }
 
     public function testRequestArchiveInvalidManifestResponse()
     {
-        /** @var \Manifesto\Client|PHPUnit_Framework_MockObject_MockObject $mockClient */
+        /** @var \Talis\Manifesto\Client|PHPUnit_Framework_MockObject_MockObject $mockClient */
         $mockClient = $this->getMock(
-            '\Manifesto\Client',
+            '\Talis\Manifesto\Client',
             array('getHeaders', 'getHTTPClient'),
             array('https://example.com/manifesto')
         );
@@ -386,7 +386,7 @@ class ClientTest extends TestBase
 
         $mockClient->setPersonaConnectValues($personaOpts);
 
-        $m = new \Manifesto\Manifest();
+        $m = new \Talis\Manifesto\Manifest();
         $m->setFormat(FORMAT_ZIP);
         $files = array();
         $file1 = array('file'=>'/path/to/file1.txt');
@@ -401,15 +401,15 @@ class ClientTest extends TestBase
         $files[] = $file3;
         $m->addFile($file3);
 
-        $this->setExpectedException('\Manifesto\Exceptions\ManifestValidationException', 'The Manifest is incomplete or contains invalid properties');
+        $this->setExpectedException('\Talis\Manifesto\Exceptions\ManifestValidationException', 'The Manifest is incomplete or contains invalid properties');
         $response = $mockClient->requestArchive($m, 'token', 'secret');
     }
 
     public function testRequestArchiveReturns404()
     {
-        /** @var \Manifesto\Client|PHPUnit_Framework_MockObject_MockObject $mockClient */
+        /** @var \Talis\Manifesto\Client|PHPUnit_Framework_MockObject_MockObject $mockClient */
         $mockClient = $this->getMock(
-            '\Manifesto\Client',
+            '\Talis\Manifesto\Client',
             array('getHeaders', 'getHTTPClient'),
             array('https://example.com/manifesto')
         );
@@ -452,7 +452,7 @@ class ClientTest extends TestBase
 
         $mockClient->setPersonaConnectValues($personaOpts);
 
-        $m = new \Manifesto\Manifest();
+        $m = new \Talis\Manifesto\Manifest();
         $m->setFormat(FORMAT_ZIP);
         $files = array();
         $file1 = array('file'=>'/path/to/file1.txt');
@@ -467,15 +467,15 @@ class ClientTest extends TestBase
         $files[] = $file3;
         $m->addFile($file3);
 
-        $this->setExpectedException('\Manifesto\Exceptions\ArchiveException', 'Misconfigured Manifesto base url');
+        $this->setExpectedException('\Talis\Manifesto\Exceptions\ArchiveException', 'Misconfigured Manifesto base url');
         $response = $mockClient->requestArchive($m, 'token', 'secret');
     }
 
     public function testRequestArchiveUnexpectedClientErrorResponse()
     {
-        /** @var \Manifesto\Client|PHPUnit_Framework_MockObject_MockObject $mockClient */
+        /** @var \Talis\Manifesto\Client|PHPUnit_Framework_MockObject_MockObject $mockClient */
         $mockClient = $this->getMock(
-            '\Manifesto\Client',
+            '\Talis\Manifesto\Client',
             array('getHeaders', 'getHTTPClient'),
             array('https://example.com/manifesto')
         );
@@ -518,7 +518,7 @@ class ClientTest extends TestBase
 
         $mockClient->setPersonaConnectValues($personaOpts);
 
-        $m = new \Manifesto\Manifest();
+        $m = new \Talis\Manifesto\Manifest();
         $m->setFormat(FORMAT_ZIP);
         $files = array();
         $file1 = array('file'=>'/path/to/file1.txt');
@@ -539,9 +539,9 @@ class ClientTest extends TestBase
 
     public function testRequestArchiveUnexpectedServerErrorResponse()
     {
-        /** @var \Manifesto\Client|PHPUnit_Framework_MockObject_MockObject $mockClient */
+        /** @var \Talis\Manifesto\Client|PHPUnit_Framework_MockObject_MockObject $mockClient */
         $mockClient = $this->getMock(
-            '\Manifesto\Client',
+            '\Talis\Manifesto\Client',
             array('getHeaders', 'getHTTPClient'),
             array('https://example.com/manifesto')
         );
@@ -584,7 +584,7 @@ class ClientTest extends TestBase
 
         $mockClient->setPersonaConnectValues($personaOpts);
 
-        $m = new \Manifesto\Manifest();
+        $m = new \Talis\Manifesto\Manifest();
         $m->setFormat(FORMAT_ZIP);
         $files = array();
         $file1 = array('file'=>'/path/to/file1.txt');
@@ -604,7 +604,7 @@ class ClientTest extends TestBase
     }
 }
 
-class TestManifestoClient extends \Manifesto\Client
+class TestManifestoClient extends \Talis\Manifesto\Client
 {
     public function getPersonaConnectValues()
     {

--- a/test/unit/Manifesto/ClientTest.php
+++ b/test/unit/Manifesto/ClientTest.php
@@ -1,6 +1,11 @@
 <?php
 
-require_once 'TestBase.php';
+$appRoot = dirname(dirname(dirname(__DIR__)));
+if (!defined('APPROOT')) {
+    define('APPROOT', $appRoot);
+}
+
+require_once $appRoot . '/test/unit/TestBase.php';
 
 class ClientTest extends TestBase
 {

--- a/test/unit/Manifesto/ManifestTest.php
+++ b/test/unit/Manifesto/ManifestTest.php
@@ -1,6 +1,11 @@
 <?php
 
-require_once 'TestBase.php';
+$appRoot = dirname(dirname(dirname(__DIR__)));
+if (!defined('APPROOT')) {
+    define('APPROOT', $appRoot);
+}
+
+require_once $appRoot . '/test/unit/TestBase.php';
 
 class ManifestTest extends TestBase {
     public function testGetSetSafeMode()

--- a/test/unit/Manifesto/ManifestTest.php
+++ b/test/unit/Manifesto/ManifestTest.php
@@ -10,53 +10,53 @@ require_once $appRoot . '/test/unit/TestBase.php';
 class ManifestTest extends TestBase {
     public function testGetSetSafeMode()
     {
-        $m = new \Manifesto\Manifest();
+        $m = new \Talis\Manifesto\Manifest();
         $this->assertFalse($m->getSafeMode());
         $m->setSafeMode(true);
         $this->assertTrue($m->getSafeMode());
 
-        $m2 = new \Manifesto\Manifest(true);
+        $m2 = new \Talis\Manifesto\Manifest(true);
         $this->assertTrue($m2->getSafeMode());
     }
 
     public function testGetSetFileCount()
     {
-        $m = new \Manifesto\Manifest();
+        $m = new \Talis\Manifesto\Manifest();
         $m->setFileCount(12);
         $this->assertEquals(12, $m->getFileCount());
     }
 
     public function testGetSetFormat()
     {
-        $m = new \Manifesto\Manifest();
+        $m = new \Talis\Manifesto\Manifest();
         $m->setFormat(FORMAT_ZIP);
         $this->assertEquals(FORMAT_ZIP, $m->getFormat());
     }
 
     public function testValidateSetFormat()
     {
-        $m = new \Manifesto\Manifest();
+        $m = new \Talis\Manifesto\Manifest();
         $this->setExpectedException('InvalidArgumentException', "'wibble' is not supported");
         $m->setFormat('wibble');
     }
 
     public function testGetSetCallbackLocation()
     {
-        $m = new \Manifesto\Manifest();
+        $m = new \Talis\Manifesto\Manifest();
         $m->setCallbackLocation('https://example.com/callback.cgi');
         $this->assertEquals('https://example.com/callback.cgi', $m->getCallbackLocation());
     }
 
     public function testValidateSetCallbackLocation()
     {
-        $m = new \Manifesto\Manifest();
+        $m = new \Talis\Manifesto\Manifest();
         $this->setExpectedException('InvalidArgumentException', "Callback location must be an http or https url");
         $m->setCallbackLocation('telnet://wibble');
     }
 
     public function testGetSetCallbackMethod()
     {
-        $m = new \Manifesto\Manifest();
+        $m = new \Talis\Manifesto\Manifest();
         $this->assertEquals('GET', $m->getCallbackMethod());
         $m->setCallbackMethod('POST');
         $this->assertEquals('POST', $m->getCallbackMethod());
@@ -66,14 +66,14 @@ class ManifestTest extends TestBase {
 
     public function testValidateSetCallbackMethod()
     {
-        $m = new \Manifesto\Manifest();
+        $m = new \Talis\Manifesto\Manifest();
         $this->setExpectedException('InvalidArgumentException', "Callback method must be GET or POST");
         $m->setCallbackMethod("PUT");
     }
 
     public function testAddGetFiles()
     {
-        $m = new \Manifesto\Manifest();
+        $m = new \Talis\Manifesto\Manifest();
         $files = array();
         $file1 = array('file'=>'/path/to/file1.txt');
         $files[] = $file1;
@@ -92,62 +92,62 @@ class ManifestTest extends TestBase {
 
     public function testValidateAddFileWithNoFileKey()
     {
-        $m = new \Manifesto\Manifest();
+        $m = new \Talis\Manifesto\Manifest();
         $this->setExpectedException('InvalidArgumentException', "Files must contain a file key and value");
         $m->addFile(array('type'=>FILE_TYPE_S3, 'container'=>'myBucket', 'destinationPath'=>'foobar.txt'));
     }
 
     public function testValidateAddFileWithNoFileValue()
     {
-        $m = new \Manifesto\Manifest();
+        $m = new \Talis\Manifesto\Manifest();
         $this->setExpectedException('InvalidArgumentException', "Files must contain a file key and value");
         $m->addFile(array('type'=>FILE_TYPE_S3, 'container'=>'myBucket', 'file'=>null, 'destinationPath'=>'foobar.txt'));
     }
 
     public function testValidateAddFileWithUnsupportedFileType()
     {
-        $m = new \Manifesto\Manifest();
+        $m = new \Talis\Manifesto\Manifest();
         $this->setExpectedException('InvalidArgumentException', "Unsupported file 'type'");
         $m->addFile(array('type'=>"MY_FOO_CLOUD", 'container'=>'myBucket', 'file'=>'/path/to/file.txt', 'destinationPath'=>'foobar.txt'));
     }
 
     public function testGenerateManifestNoFiles()
     {
-        $m = new \Manifesto\Manifest();
-        $this->setExpectedException('Manifesto\Exceptions\ManifestValidationException', 'No files have been added to manifest');
+        $m = new \Talis\Manifesto\Manifest();
+        $this->setExpectedException('Talis\Manifesto\Exceptions\ManifestValidationException', 'No files have been added to manifest');
         $m->generateManifest();
     }
 
     public function testGenerateManifestNoFormat()
     {
-        $m = new \Manifesto\Manifest();
+        $m = new \Talis\Manifesto\Manifest();
         $m->addFile(array('file'=>'/path/to/file1.txt'));
-        $this->setExpectedException('Manifesto\Exceptions\ManifestValidationException', 'Output format has not been set');
+        $this->setExpectedException('Talis\Manifesto\Exceptions\ManifestValidationException', 'Output format has not been set');
         $m->generateManifest();
     }
 
     public function testGenerateManifestNoFileCountInSafeMode()
     {
-        $m = new \Manifesto\Manifest(true);
+        $m = new \Talis\Manifesto\Manifest(true);
         $m->addFile(array('file'=>'/path/to/file1.txt'));
         $m->setFormat(FORMAT_TARBZ);
-        $this->setExpectedException('Manifesto\Exceptions\ManifestValidationException', 'File count must be set in safe mode');
+        $this->setExpectedException('Talis\Manifesto\Exceptions\ManifestValidationException', 'File count must be set in safe mode');
         $m->generateManifest();
     }
 
     public function testGenerateManifestWrongFileCountInSafeMode()
     {
-        $m = new \Manifesto\Manifest(true);
+        $m = new \Talis\Manifesto\Manifest(true);
         $m->addFile(array('file'=>'/path/to/file1.txt'));
         $m->setFormat(FORMAT_TARBZ);
         $m->setFileCount(3);
-        $this->setExpectedException('Manifesto\Exceptions\ManifestValidationException', 'Number of files does not equal fileCount');
+        $this->setExpectedException('Talis\Manifesto\Exceptions\ManifestValidationException', 'Number of files does not equal fileCount');
         $m->generateManifest();
     }
 
     public function testBasicManifest()
     {
-        $m = new \Manifesto\Manifest();
+        $m = new \Talis\Manifesto\Manifest();
         $m->setFormat(FORMAT_ZIP);
         $files = array();
         $file1 = array('file'=>'/path/to/file1.txt');
@@ -173,7 +173,7 @@ class ManifestTest extends TestBase {
 
     public function testAdvancedManifest()
     {
-        $m = new \Manifesto\Manifest(true);
+        $m = new \Talis\Manifesto\Manifest(true);
         $m->setFormat(FORMAT_TARBZ);
         $files = array();
         $file1 = array('file'=>'/path/to/file1.txt');

--- a/test/unit/Manifesto/ManifestTest.php
+++ b/test/unit/Manifesto/ManifestTest.php
@@ -1,0 +1,200 @@
+<?php
+
+require_once 'TestBase.php';
+
+class ManifestTest extends TestBase {
+    public function testGetSetSafeMode()
+    {
+        $m = new \Manifesto\Manifest();
+        $this->assertFalse($m->getSafeMode());
+        $m->setSafeMode(true);
+        $this->assertTrue($m->getSafeMode());
+
+        $m2 = new \Manifesto\Manifest(true);
+        $this->assertTrue($m2->getSafeMode());
+    }
+
+    public function testGetSetFileCount()
+    {
+        $m = new \Manifesto\Manifest();
+        $m->setFileCount(12);
+        $this->assertEquals(12, $m->getFileCount());
+    }
+
+    public function testGetSetFormat()
+    {
+        $m = new \Manifesto\Manifest();
+        $m->setFormat(FORMAT_ZIP);
+        $this->assertEquals(FORMAT_ZIP, $m->getFormat());
+    }
+
+    public function testValidateSetFormat()
+    {
+        $m = new \Manifesto\Manifest();
+        $this->setExpectedException('InvalidArgumentException', "'wibble' is not supported");
+        $m->setFormat('wibble');
+    }
+
+    public function testGetSetCallbackLocation()
+    {
+        $m = new \Manifesto\Manifest();
+        $m->setCallbackLocation('https://example.com/callback.cgi');
+        $this->assertEquals('https://example.com/callback.cgi', $m->getCallbackLocation());
+    }
+
+    public function testValidateSetCallbackLocation()
+    {
+        $m = new \Manifesto\Manifest();
+        $this->setExpectedException('InvalidArgumentException', "Callback location must be an http or https url");
+        $m->setCallbackLocation('telnet://wibble');
+    }
+
+    public function testGetSetCallbackMethod()
+    {
+        $m = new \Manifesto\Manifest();
+        $this->assertEquals('GET', $m->getCallbackMethod());
+        $m->setCallbackMethod('POST');
+        $this->assertEquals('POST', $m->getCallbackMethod());
+        $m->setCallbackMethod('get');
+        $this->assertEquals('GET', $m->getCallbackMethod());
+    }
+
+    public function testValidateSetCallbackMethod()
+    {
+        $m = new \Manifesto\Manifest();
+        $this->setExpectedException('InvalidArgumentException', "Callback method must be GET or POST");
+        $m->setCallbackMethod("PUT");
+    }
+
+    public function testAddGetFiles()
+    {
+        $m = new \Manifesto\Manifest();
+        $files = array();
+        $file1 = array('file'=>'/path/to/file1.txt');
+        $files[] = $file1;
+        $m->addFile($file1);
+
+        $file2 = array('type'=>FILE_TYPE_S3, 'container'=>'myBucket', 'file'=>'/path/to/file2.txt', 'destinationPath'=>'foobar.txt');
+        $files[] = $file2;
+        $m->addFile($file2);
+
+        $file3 = array('type'=>FILE_TYPE_CF, 'file'=>'/path/to/file3.txt', 'destinationPath'=>'/another/path/foobar.txt');
+        $files[] = $file3;
+        $m->addFile($file3);
+
+        $this->assertEquals($files, $m->getFiles());
+    }
+
+    public function testValidateAddFileWithNoFileKey()
+    {
+        $m = new \Manifesto\Manifest();
+        $this->setExpectedException('InvalidArgumentException', "Files must contain a file key and value");
+        $m->addFile(array('type'=>FILE_TYPE_S3, 'container'=>'myBucket', 'destinationPath'=>'foobar.txt'));
+    }
+
+    public function testValidateAddFileWithNoFileValue()
+    {
+        $m = new \Manifesto\Manifest();
+        $this->setExpectedException('InvalidArgumentException', "Files must contain a file key and value");
+        $m->addFile(array('type'=>FILE_TYPE_S3, 'container'=>'myBucket', 'file'=>null, 'destinationPath'=>'foobar.txt'));
+    }
+
+    public function testValidateAddFileWithUnsupportedFileType()
+    {
+        $m = new \Manifesto\Manifest();
+        $this->setExpectedException('InvalidArgumentException', "Unsupported file 'type'");
+        $m->addFile(array('type'=>"MY_FOO_CLOUD", 'container'=>'myBucket', 'file'=>'/path/to/file.txt', 'destinationPath'=>'foobar.txt'));
+    }
+
+    public function testGenerateManifestNoFiles()
+    {
+        $m = new \Manifesto\Manifest();
+        $this->setExpectedException('Manifesto\Exceptions\ManifestValidationException', 'No files have been added to manifest');
+        $m->generateManifest();
+    }
+
+    public function testGenerateManifestNoFormat()
+    {
+        $m = new \Manifesto\Manifest();
+        $m->addFile(array('file'=>'/path/to/file1.txt'));
+        $this->setExpectedException('Manifesto\Exceptions\ManifestValidationException', 'Output format has not been set');
+        $m->generateManifest();
+    }
+
+    public function testGenerateManifestNoFileCountInSafeMode()
+    {
+        $m = new \Manifesto\Manifest(true);
+        $m->addFile(array('file'=>'/path/to/file1.txt'));
+        $m->setFormat(FORMAT_TARBZ);
+        $this->setExpectedException('Manifesto\Exceptions\ManifestValidationException', 'File count must be set in safe mode');
+        $m->generateManifest();
+    }
+
+    public function testGenerateManifestWrongFileCountInSafeMode()
+    {
+        $m = new \Manifesto\Manifest(true);
+        $m->addFile(array('file'=>'/path/to/file1.txt'));
+        $m->setFormat(FORMAT_TARBZ);
+        $m->setFileCount(3);
+        $this->setExpectedException('Manifesto\Exceptions\ManifestValidationException', 'Number of files does not equal fileCount');
+        $m->generateManifest();
+    }
+
+    public function testBasicManifest()
+    {
+        $m = new \Manifesto\Manifest();
+        $m->setFormat(FORMAT_ZIP);
+        $files = array();
+        $file1 = array('file'=>'/path/to/file1.txt');
+        $files[] = $file1;
+        $m->addFile($file1);
+
+        $file2 = array('type'=>FILE_TYPE_S3, 'container'=>'myBucket', 'file'=>'/path/to/file2.txt', 'destinationPath'=>'foobar.txt');
+        $files[] = $file2;
+        $m->addFile($file2);
+
+        $file3 = array('type'=>FILE_TYPE_CF, 'file'=>'/path/to/file3.txt', 'destinationPath'=>'/another/path/foobar.txt');
+        $files[] = $file3;
+        $m->addFile($file3);
+
+        $expectedManifest = array(
+            'format'=>FORMAT_ZIP,
+            'fileCount'=>3,
+            'files'=>$files
+        );
+
+        $this->assertEquals($expectedManifest, $m->generateManifest());
+    }
+
+    public function testAdvancedManifest()
+    {
+        $m = new \Manifesto\Manifest(true);
+        $m->setFormat(FORMAT_TARBZ);
+        $files = array();
+        $file1 = array('file'=>'/path/to/file1.txt');
+        $files[] = $file1;
+        $m->addFile($file1);
+
+        $file2 = array('type'=>FILE_TYPE_S3, 'container'=>'myBucket', 'file'=>'/path/to/file2.txt', 'destinationPath'=>'foobar.txt');
+        $files[] = $file2;
+        $m->addFile($file2);
+
+        $file3 = array('type'=>FILE_TYPE_CF, 'file'=>'/path/to/file3.txt', 'destinationPath'=>'/another/path/foobar.txt');
+        $files[] = $file3;
+        $m->addFile($file3);
+
+        $m->setFileCount(3);
+
+        $m->setCallbackLocation('https://example.com/callback.cgi');
+        $m->setCallbackMethod('post');
+
+        $expectedManifest = array(
+            'callback'=>array('url'=>'https://example.com/callback.cgi', 'method'=>'POST'),
+            'format'=>FORMAT_TARBZ,
+            'fileCount'=>3,
+            'files'=>$files
+        );
+
+        $this->assertEquals($expectedManifest, $m->generateManifest());
+    }
+}


### PR DESCRIPTION
https://github.com/talis/enterprise/issues/1048 is to migrate DC to talis-php. However, to do this manifesto-php-client needs to be available in talis-php. This work adds in manifesto-php-client.

It's more or less like for like. The only changes in the code are to the namespace.

Also updated the readme. The Dockerfile contains all the steps added, but for some reason, I still needed to run them manually after the container had completed.

> N.B.
> I couldn't get the integration tests to pass locally, but they passed on Travis. I chose not to investigate any further. If anyone knows how to resolve I'm all 👂  