### PR TITLE
PLAT-3418 - Fix Travis Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ services:
 - redis-server
 sudo: false
 language: php
+dist: trusty
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ services:
 - redis-server
 sudo: false
 language: php
+addons:
+  apt:
+    packages:
+      ant
 php:
 - 7.2
 - 7.1

--- a/README.md
+++ b/README.md
@@ -57,4 +57,3 @@ docker-compose run test
 docker-compose run unittest
 docker-compose run integrationtest
 ```
-

--- a/README.md
+++ b/README.md
@@ -57,3 +57,4 @@ docker-compose run test
 docker-compose run unittest
 docker-compose run integrationtest
 ```
+


### PR DESCRIPTION
## Problem

The Travis build for talis-php is failing.

#### 5.5 Failure
```
0.02s$ phpenv global 5.5 2>/dev/null
5.5 is not pre-installed; installing
Downloading archive: https://storage.googleapis.com/travis-ci-language-archives/php/binaries/ubuntu/16.04/x86_64/php-5.5.tar.bz2
0.10s$ curl -sSf --retry 5 -o archive.tar.bz2 $archive_url && tar xjf archive.tar.bz2 --directory /
curl: (22) The requested URL returned error: 404 Not Found
0.00sNaNs$ phpenv global 5.5
rbenv: version `5.5' not installed
The command "phpenv global 5.5" failed and exited with 1 during .
```

#### 5.6 .. 7.2 Failure

```
No syntax errors detected in ./test/unit/Echo/ClientTest.php
No syntax errors detected in ./test/unit/Babel/ClientTest.php
No syntax errors detected in ./test/unit/TestBase.php
++ant test
++'[' -x /usr/lib/command-not-found ']'
++/usr/lib/command-not-found -- ant
The program 'ant' is currently not installed. To run 'ant' please ask your administrator to install the package 'ant'
```

## Fix

This PR installs ant to fix the 5.6 to 7.2 inclusive builds. 

The build image is pinned to trusty which is needed to be able to install PHP 5.5. (This may mean that ant is installed by default without specifying it explicitly, but we are using it, and when we do move to Xenial or later it might not be there. We're using it - lets be explicit. )


