### PR TITLE
PLAT-3484 update guzzle

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ changes.
 
 Before releasing for general usage there will be major changes to the API. The library will move
 away from the use of internal Talis project names like Persona, Critic, Babel and Echo etc.
-Instead it will use more externally relavant names like ```ListReviews``` and ```Files```.
+Instead it will use more externally relevant names like ```ListReviews``` and ```Files```.
 The API will also move to a more domain driven design rather than the service driven design
 of the individual libraries
 
@@ -44,7 +44,7 @@ Manually run persona locally:
 
 # Create an OAuth Client and Secret
 
-To build the talis-php docker container, you need to specify an oauth client and secret to use. This client should have `su` scope. It's not possibe to create a client with `su` scope via the API.
+To build the talis-php docker container, you need to specify an oauth client and secret to use. This client should have `su` scope. It's not possible to create a client with `su` scope via the API.
 
 First - create a client:
 
@@ -103,7 +103,7 @@ service redis-server start
 source /etc/profile.d/*
 ```
 
-You can the bun ant commands individually or run individual tests:
+You can then run ant commands individually or run individual tests:
 
 ```bash
 /vendor/bin/phpunit --filter testCreateUserThenPatchOAuthClientAddScope test/integration/

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
     "firebase/php-jwt": "^3.0",
     "doctrine/common": "^2.5",
     "predis/predis"  : ">=0.8.5",
-    "guzzle/guzzle": "^3.8",
     "guzzlehttp/guzzle": "^6.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "talis/talis-php",
-  "description": "This is a php client library for talis api's",
-  "version": "0.3.1",
+  "description": "This is a php client library for talis APIs",
+  "version": "0.5.0",
   "keywords": [
     "persona",
     "echo",
@@ -15,13 +15,14 @@
   "type": "library",
   "license": "MIT",
   "require": {
-    "php": ">=5.3.0",
+    "php": ">=5.5.9",
     "monolog/monolog": ">=1.13.1",
     "psr/log": ">=1.0.0",
     "firebase/php-jwt": "^3.0",
     "doctrine/common": "^2.5",
-    "predis/predis"  : "v0.8.5",
-    "guzzle/guzzle": "^3.8"
+    "predis/predis"  : ">=0.8.5",
+    "guzzle/guzzle": "^3.8",
+    "guzzlehttp/guzzle": "^6.0"
   },
   "require-dev": {
     "phpunit/phpunit": "4.8.36",

--- a/src/Talis/EchoClient/Base.php
+++ b/src/Talis/EchoClient/Base.php
@@ -77,11 +77,11 @@ abstract class Base
     /**
      * To allow mocking of the Guzzle client for testing.
      *
-     * @return Client
+     * @return \GuzzleHttp\Client
      */
     protected function getHttpClient()
     {
-        return new \Guzzle\Http\Client();
+        return new \GuzzleHttp\Client();
     }
 
     /**

--- a/src/Talis/Persona/Client/Tokens.php
+++ b/src/Talis/Persona/Client/Tokens.php
@@ -181,7 +181,7 @@ class Tokens extends Base
                 ]
             );
 
-            return $response->__toString();
+            return (string) $response;
         } catch (\Exception $e) {
             $this->getLogger()->warning(
                 'could not retrieve persona public certificate'

--- a/test/TestBase.php
+++ b/test/TestBase.php
@@ -8,13 +8,6 @@ abstract class TestBase extends \PHPUnit_Framework_TestCase
 {
     protected $cacheBackend = null;
 
-    public function __construct()
-    {
-        $this->cacheBackend = new FilesystemCache(
-            sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'personaCache'
-        );
-    }
-
     protected function removeCacheFolder()
     {
         $dir = '/tmp/personaCache';
@@ -53,6 +46,9 @@ abstract class TestBase extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->removeCacheFolder();
+        $this->cacheBackend = new FilesystemCache(
+            sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'personaCache'
+        );
         $className = get_class($this);
         $testName = $this->getName();
         echo " Test: {$className}->{$testName}\n";

--- a/test/unit/Persona/LoginTest.php
+++ b/test/unit/Persona/LoginTest.php
@@ -51,7 +51,7 @@ class LoginTest extends TestBase
 
     public function testRequireAuthNoRedirectUri()
     {
-        $mockClient = $this->getMock('Talis\Persona\Client\Login', ['login'], [
+        $mockClient = $this->getMock(\Talis\Persona\Client\Login::class, ['login'], [
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
@@ -84,7 +84,7 @@ class LoginTest extends TestBase
 
     public function testRequireAuthWithRedirectUri()
     {
-        $mockClient = $this->getMock('Talis\Persona\Client\Login', ['login'], [
+        $mockClient = $this->getMock(\Talis\Persona\Client\Login::class, ['login'], [
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
@@ -104,7 +104,7 @@ class LoginTest extends TestBase
 
     public function testRequireAuthAlreadyLoggedIn()
     {
-        $mockClient = $this->getMock('Talis\Persona\Client\Login', ['isLoggedIn', 'login'], [
+        $mockClient = $this->getMock(\Talis\Persona\Client\Login::class, ['isLoggedIn', 'login'], [
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
@@ -123,7 +123,7 @@ class LoginTest extends TestBase
 
     public function testRequireAuthNotAlreadyLoggedIn()
     {
-        $mockClient = $this->getMock('Talis\Persona\Client\Login', ['isLoggedIn', 'login'], [
+        $mockClient = $this->getMock(\Talis\Persona\Client\Login::class, ['isLoggedIn', 'login'], [
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
@@ -315,7 +315,7 @@ class LoginTest extends TestBase
 
     public function testValidateAuthPayloadContainsStateAndSignatureFullPayloadCheckLoginIsCalled()
     {
-        $mockClient = $this->getMock('Talis\Persona\Client\Login', ['isLoggedIn'], [
+        $mockClient = $this->getMock(\Talis\Persona\Client\Login::class, ['isLoggedIn'], [
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
@@ -358,7 +358,7 @@ class LoginTest extends TestBase
 
     public function testValidateAuthAfterRequireAuth()
     {
-        $mockClient = $this->getMock('Talis\Persona\Client\Login', ['isLoggedIn', 'login'], [
+        $mockClient = $this->getMock(\Talis\Persona\Client\Login::class, ['isLoggedIn', 'login'], [
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
@@ -630,7 +630,7 @@ class LoginTest extends TestBase
         ];
 
         $client = $this->getMock(
-            'Talis\Persona\Client\Login',
+            \Talis\Persona\Client\Login::class,
             ['redirect', 'getLoginState'],
             $arguments
         );

--- a/test/unit/Persona/OAuthClientsTest.php
+++ b/test/unit/Persona/OAuthClientsTest.php
@@ -38,7 +38,7 @@ class OAuthClientsTest extends TestBase
     public function testGetOAuthClientThrowsExceptionWhenClientNotFound()
     {
         $this->setExpectedException('Exception', 'Did not retrieve successful response code');
-        $mockClient = $this->getMock('Talis\Persona\Client\OAuthClients', ['personaGetOAuthClient'], [
+        $mockClient = $this->getMock(\Talis\Persona\Client\OAuthClients::class, ['personaGetOAuthClient'], [
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
@@ -54,7 +54,7 @@ class OAuthClientsTest extends TestBase
 
     public function testGetOAuthClientReturnsClientWhenGupidFound()
     {
-        $mockClient = $this->getMock('Talis\Persona\Client\OAuthClients', ['personaGetOAuthClient'], [
+        $mockClient = $this->getMock(\Talis\Persona\Client\OAuthClients::class, ['personaGetOAuthClient'], [
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
@@ -225,7 +225,7 @@ class OAuthClientsTest extends TestBase
     public function testUpdateOAuthClientPutFails()
     {
         $this->setExpectedException('Exception', 'Could not retrieve OAuth response code');
-        $mockClient = $this->getMock('Talis\Persona\Client\OAuthClients', ['personaPatchOAuthClient'], [
+        $mockClient = $this->getMock(\Talis\Persona\Client\OAuthClients::class, ['personaPatchOAuthClient'], [
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
@@ -241,7 +241,7 @@ class OAuthClientsTest extends TestBase
 
     public function testUpdateOAuthClientPutSucceeds()
     {
-        $mockClient = $this->getMock('Talis\Persona\Client\OAuthClients', ['personaPatchOAuthClient'], [
+        $mockClient = $this->getMock(\Talis\Persona\Client\OAuthClients::class, ['personaPatchOAuthClient'], [
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
@@ -267,7 +267,7 @@ class OAuthClientsTest extends TestBase
     public function testRegenerateSecretNon200Exception()
     {
         $oauthClient = $this->getMock(
-            'Talis\Persona\Client\OAuthClients',
+            \Talis\Persona\Client\OAuthClients::class,
             ['performRequest'],
             [
                 [
@@ -305,7 +305,7 @@ class OAuthClientsTest extends TestBase
     public function testRegenerateSecretInvalidResponsePayload()
     {
         $oauthClient = $this->getMock(
-            'Talis\Persona\Client\OAuthClients',
+            \Talis\Persona\Client\OAuthClients::class,
             ['performRequest'],
             [
                 [
@@ -339,7 +339,7 @@ class OAuthClientsTest extends TestBase
     public function testRegenerateSecretHappyPath()
     {
         $oauthClient = $this->getMock(
-            'Talis\Persona\Client\OAuthClients',
+            \Talis\Persona\Client\OAuthClients::class,
             ['performRequest'],
             [
                 [

--- a/test/unit/Persona/TokensTest.php
+++ b/test/unit/Persona/TokensTest.php
@@ -63,8 +63,9 @@ class TokensTest extends TestBase
 
     public function testUseCacheFalseOnObtainToken()
     {
+        /** @var \Talis\Persona\Client\Tokens|\PHPUnit_Framework_MockObject_MockObject $mockClient */
         $mockClient = $this->getMock(
-            'Talis\Persona\Client\Tokens',
+            \Talis\Persona\Client\Tokens::class,
             ['personaObtainNewToken'],
             [
                 [
@@ -92,8 +93,9 @@ class TokensTest extends TestBase
 
     public function testObtainToken()
     {
+        /** @var \Talis\Persona\Client\Tokens|\PHPUnit_Framework_MockObject_MockObject $mockClient */
         $mockClient = $this->getMock(
-            'Talis\Persona\Client\Tokens',
+            \Talis\Persona\Client\Tokens::class,
             ['personaObtainNewToken'],
             [
                 [
@@ -126,8 +128,9 @@ class TokensTest extends TestBase
      */
     public function testPersonaFallbackOnJWTEmptyScopes()
     {
+        /** @var \Talis\Persona\Client\Tokens|\PHPUnit_Framework_MockObject_MockObject $mockClient */
         $mockClient = $this->getMock(
-            'Talis\Persona\Client\Tokens',
+            \Talis\Persona\Client\Tokens::class,
             [
                 'getCacheClient',
                 'personaObtainNewToken',
@@ -176,8 +179,9 @@ class TokensTest extends TestBase
 
     public function testPersonaFallbackWhenUnableToGetPublicCert()
     {
+        /** @var \Talis\Persona\Client\Tokens|\PHPUnit_Framework_MockObject_MockObject $mockClient */
         $mockClient = $this->getMock(
-            'Talis\Persona\Client\Tokens',
+            \Talis\Persona\Client\Tokens::class,
             [
                 'getCacheClient',
                 'personaObtainNewToken',
@@ -229,8 +233,9 @@ class TokensTest extends TestBase
      */
     public function testJWTExpiredToken()
     {
+        /** @var \Talis\Persona\Client\Tokens|\PHPUnit_Framework_MockObject_MockObject $mockClient */
         $mockClient = $this->getMock(
-            'Talis\Persona\Client\Tokens',
+            \Talis\Persona\Client\Tokens::class,
             ['retrieveJWTCertificate'],
             [
                 [
@@ -273,8 +278,9 @@ class TokensTest extends TestBase
      */
     public function testJWTNotBeforeToken()
     {
+        /** @var \Talis\Persona\Client\Tokens|\PHPUnit_Framework_MockObject_MockObject $mockClient */
         $mockClient = $this->getMock(
-            'Talis\Persona\Client\Tokens',
+            \Talis\Persona\Client\Tokens::class,
             ['retrieveJWTCertificate'],
             [
                 [
@@ -317,8 +323,9 @@ class TokensTest extends TestBase
      */
     public function testJWTInvalidPublicCert()
     {
+        /** @var \Talis\Persona\Client\Tokens|\PHPUnit_Framework_MockObject_MockObject $mockClient */
         $mockClient = $this->getMock(
-            'Talis\Persona\Client\Tokens',
+            \Talis\Persona\Client\Tokens::class,
             ['retrieveJWTCertificate'],
             [
                 [
@@ -356,8 +363,9 @@ class TokensTest extends TestBase
      */
     public function testReturnUnexpectedStatusCode()
     {
+        /** @var \Talis\Persona\Client\Tokens|\PHPUnit_Framework_MockObject_MockObject $mockClient */
         $mockClient = $this->getMock(
-            'Talis\Persona\Client\Tokens',
+            \Talis\Persona\Client\Tokens::class,
             ['getHTTPClient', 'validateTokenUsingJWT'],
             [
                 [
@@ -368,10 +376,9 @@ class TokensTest extends TestBase
             ]
         );
 
-        $plugin = new \Guzzle\Plugin\Mock\MockPlugin();
-        $plugin->addResponse(new \Guzzle\Http\Message\Response(202));
-        $httpClient = new \Guzzle\Http\Client();
-        $httpClient->addSubscriber($plugin);
+        $httpClient = $this->getMockHttpClient([
+            new \GuzzleHttp\Psr7\Response(202),
+        ]);
 
         $jwt = JWT::encode(
             [
@@ -413,8 +420,9 @@ class TokensTest extends TestBase
      */
     public function testObtainCachedToken()
     {
+        /** @var \Talis\Persona\Client\Tokens|\PHPUnit_Framework_MockObject_MockObject $mockClient */
         $mockClient = $this->getMock(
-            'Talis\Persona\Client\Tokens',
+            \Talis\Persona\Client\Tokens::class,
             ['getHTTPClient'],
             [
                 [
@@ -444,12 +452,9 @@ class TokensTest extends TestBase
             ]
         );
 
-        $plugin = new \Guzzle\Plugin\Mock\MockPlugin();
-        $plugin->addResponse(
-            new \Guzzle\Http\Message\Response(200, null, $accessToken)
-        );
-        $httpClient = new \Guzzle\Http\Client();
-        $httpClient->addSubscriber($plugin);
+        $httpClient = $this->getMockHttpClient([
+            new \GuzzleHttp\Psr7\Response(200, [], $accessToken),
+        ]);
 
         $mockClient->expects($this->once())
             ->method('getHTTPClient')
@@ -473,8 +478,9 @@ class TokensTest extends TestBase
 
     public function testRemoteValidationCallsUseSuScopeCheckForSu()
     {
+        /** @var \Talis\Persona\Client\Tokens|\PHPUnit_Framework_MockObject_MockObject $mockClient */
         $mockClient = $this->getMock(
-            'Talis\Persona\Client\Tokens',
+            \Talis\Persona\Client\Tokens::class,
             ['validateTokenUsingJWT', 'makePersonaHttpRequest'],
             [
                 [
@@ -537,8 +543,9 @@ class TokensTest extends TestBase
 
     public function testRemoteValidationCallsMultipleScopes()
     {
+        /** @var \Talis\Persona\Client\Tokens|\PHPUnit_Framework_MockObject_MockObject $mockClient */
         $mockClient = $this->getMock(
-            'Talis\Persona\Client\Tokens',
+            \Talis\Persona\Client\Tokens::class,
             ['validateTokenUsingJWT', 'makePersonaHttpRequest'],
             [
                 [
@@ -600,8 +607,9 @@ class TokensTest extends TestBase
 
     public function testRemoteValidationCallsMultipleScopesWithSu()
     {
+        /** @var \Talis\Persona\Client\Tokens|\PHPUnit_Framework_MockObject_MockObject $mockClient */
         $mockClient = $this->getMock(
-            'Talis\Persona\Client\Tokens',
+            \Talis\Persona\Client\Tokens::class,
             ['validateTokenUsingJWT', 'makePersonaHttpRequest'],
             [
                 [
@@ -664,8 +672,9 @@ class TokensTest extends TestBase
 
     public function testLocalValidationCallsMultipleScopes()
     {
+        /** @var \Talis\Persona\Client\Tokens|\PHPUnit_Framework_MockObject_MockObject $mockClient */
         $mockClient = $this->getMock(
-            'Talis\Persona\Client\Tokens',
+            \Talis\Persona\Client\Tokens::class,
             ['retrieveJWTCertificate'],
             [
                 [
@@ -704,8 +713,9 @@ class TokensTest extends TestBase
 
     public function testLocalValidationCallsMultipleScopesWithSu()
     {
+        /** @var \Talis\Persona\Client\Tokens|\PHPUnit_Framework_MockObject_MockObject $mockClient */
         $mockClient = $this->getMock(
-            'Talis\Persona\Client\Tokens',
+            \Talis\Persona\Client\Tokens::class,
             ['retrieveJWTCertificate'],
             [
                 [
@@ -838,8 +848,9 @@ class TokensTest extends TestBase
 
     public function testListScopes()
     {
+        /** @var \Talis\Persona\Client\Tokens|\PHPUnit_Framework_MockObject_MockObject $mockClient */
         $mockClient = $this->getMock(
-            'Talis\Persona\Client\Tokens',
+            \Talis\Persona\Client\Tokens::class,
             ['retrieveJWTCertificate'],
             [
                 [
@@ -874,8 +885,9 @@ class TokensTest extends TestBase
 
     public function testListScopesInvalidDomain()
     {
+        /** @var \Talis\Persona\Client\Tokens|\PHPUnit_Framework_MockObject_MockObject $mockClient */
         $mockClient = $this->getMock(
-            'Talis\Persona\Client\Tokens',
+            \Talis\Persona\Client\Tokens::class,
             ['retrieveJWTCertificate'],
             [
                 [
@@ -910,8 +922,9 @@ class TokensTest extends TestBase
 
     public function testListScopesScopeCount()
     {
+        /** @var \Talis\Persona\Client\Tokens|\PHPUnit_Framework_MockObject_MockObject $mockClient */
         $mockClient = $this->getMock(
-            'Talis\Persona\Client\Tokens',
+            \Talis\Persona\Client\Tokens::class,
             [
                 'retrieveJWTCertificate',
                 'makePersonaHttpRequest',
@@ -958,8 +971,9 @@ class TokensTest extends TestBase
 
     public function testListScopesScopeCountInvalidDomain()
     {
+        /** @var \Talis\Persona\Client\Tokens|\PHPUnit_Framework_MockObject_MockObject $mockClient */
         $mockClient = $this->getMock(
-            'Talis\Persona\Client\Tokens',
+            \Talis\Persona\Client\Tokens::class,
             [
                 'retrieveJWTCertificate',
                 'makePersonaHttpRequest',
@@ -1018,8 +1032,9 @@ class TokensTest extends TestBase
             ->method('doFetch')
             ->will($this->throwException(new \Exception('I failed')));
 
+        /** @var \Talis\Persona\Client\Tokens|\PHPUnit_Framework_MockObject_MockObject $tokens */
         $tokens = $this->getMock(
-            'Talis\Persona\Client\Tokens',
+            \Talis\Persona\Client\Tokens::class,
             ['personaObtainNewToken'],
             [
                 [
@@ -1058,8 +1073,9 @@ class TokensTest extends TestBase
             ->method('doSave')
             ->will($this->throwException(new \Exception('cannot save')));
 
+        /** @var \Talis\Persona\Client\Tokens|\PHPUnit_Framework_MockObject_MockObject $tokens */
         $tokens = $this->getMock(
-            'Talis\Persona\Client\Tokens',
+            \Talis\Persona\Client\Tokens::class,
             ['personaObtainNewToken'],
             [
                 [
@@ -1094,8 +1110,9 @@ class TokensTest extends TestBase
             ->method('doFetch')
             ->will($this->throwException(new \Exception('I failed')));
 
+        /** @var \Talis\Persona\Client\Tokens|\PHPUnit_Framework_MockObject_MockObject $tokens */
         $tokens = $this->getMock(
-            'Talis\Persona\Client\Tokens',
+            \Talis\Persona\Client\Tokens::class,
             ['retrievePublicKeyFromPersona'],
             [
                 [
@@ -1128,8 +1145,9 @@ class TokensTest extends TestBase
             ->method('doFetch')
             ->willReturn(null);
 
+        /** @var \Talis\Persona\Client\Tokens|\PHPUnit_Framework_MockObject_MockObject $tokens */
         $tokens = $this->getMock(
-            'Talis\Persona\Client\Tokens',
+            \Talis\Persona\Client\Tokens::class,
             ['retrievePublicKeyFromPersona'],
             [
                 [
@@ -1165,13 +1183,13 @@ class TokensTest extends TestBase
                 ['[cert_pub][1]', 'cert', 300]
             );
 
-        $plugin = new \Guzzle\Plugin\Mock\MockPlugin();
-        $plugin->addResponse(new \Guzzle\Http\Message\Response(200, null, 'cert'));
-        $httpClient = new \Guzzle\Http\Client();
-        $httpClient->addSubscriber($plugin);
+        $httpClient = $this->getMockHttpClient([
+            new \GuzzleHttp\Psr7\Response(200, [], 'cert'),
+        ]);
 
+        /** @var \Talis\Persona\Client\Tokens|\PHPUnit_Framework_MockObject_MockObject $tokens */
         $tokens = $this->getMock(
-            'Talis\Persona\Client\Tokens',
+            \Talis\Persona\Client\Tokens::class,
             ['getHTTPClient', 'getVersionFromComposeFile'],
             [
                 [
@@ -1217,13 +1235,13 @@ class TokensTest extends TestBase
                 ['[cert_pub][1]', 'cert', 300]
             );
 
-        $plugin = new \Guzzle\Plugin\Mock\MockPlugin();
-        $plugin->addResponse(new \Guzzle\Http\Message\Response(200, null, 'cert'));
-        $httpClient = new \Guzzle\Http\Client();
-        $httpClient->addSubscriber($plugin);
+        $httpClient = $this->getMockHttpClient([
+            new \GuzzleHttp\Psr7\Response(200, [], 'cert'),
+        ]);
 
+        /** @var \Talis\Persona\Client\Tokens|\PHPUnit_Framework_MockObject_MockObject $tokens */
         $tokens = $this->getMock(
-            'Talis\Persona\Client\Tokens',
+            \Talis\Persona\Client\Tokens::class,
             ['getHTTPClient', 'getVersionFromComposeFile'],
             [
                 [
@@ -1263,13 +1281,13 @@ class TokensTest extends TestBase
             )
             ->will($this->throwException(new \Exception('oh no')));
 
-        $plugin = new \Guzzle\Plugin\Mock\MockPlugin();
-        $plugin->addResponse(new \Guzzle\Http\Message\Response(200, null, 'cert'));
-        $httpClient = new \Guzzle\Http\Client();
-        $httpClient->addSubscriber($plugin);
+        $httpClient = $this->getMockHttpClient([
+            new \GuzzleHttp\Psr7\Response(200, [], 'cert'),
+        ]);
 
+        /** @var \Talis\Persona\Client\Tokens|\PHPUnit_Framework_MockObject_MockObject $tokens */
         $tokens = $this->getMock(
-            'Talis\Persona\Client\Tokens',
+            \Talis\Persona\Client\Tokens::class,
             ['getHTTPClient', 'getVersionFromComposeFile'],
             [
                 [
@@ -1289,5 +1307,20 @@ class TokensTest extends TestBase
             ->willReturn('0.0.1');
 
         $tokens->retrieveJWTCertificate();
+    }
+
+    /**
+     * Gets the client with mocked HTTP responses.
+     *
+     * @param \GuzzleHttp\Psr7\Response[] $responses The responses
+     * @return \GuzzleHttp\Client The client.
+     */
+    private function getMockHttpClient(array $responses = [])
+    {
+        $mockHandler = new \GuzzleHttp\Handler\MockHandler($responses);
+        $handlerStack = \GuzzleHttp\HandlerStack::create($mockHandler);
+        $httpClient = new \GuzzleHttp\Client(['handler' => $handlerStack]);
+
+        return $httpClient;
     }
 }

--- a/test/unit/Persona/UsersTest.php
+++ b/test/unit/Persona/UsersTest.php
@@ -36,7 +36,7 @@ class UsersTest extends TestBase
     public function testGetUserByGupidThrowsExceptionWhenGupidNotFound()
     {
         $this->setExpectedException('Exception', 'Did not retrieve successful response code');
-        $mockClient = $this->getMock('Talis\Persona\Client\Users', ['performRequest'], [
+        $mockClient = $this->getMock(\Talis\Persona\Client\Users::class, ['performRequest'], [
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
@@ -52,7 +52,7 @@ class UsersTest extends TestBase
 
     public function testGetUserByGupidReturnsUserWhenGupidFound()
     {
-        $mockClient = $this->getMock('Talis\Persona\Client\Users', ['performRequest'], [
+        $mockClient = $this->getMock(\Talis\Persona\Client\Users::class, ['performRequest'], [
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
@@ -98,7 +98,7 @@ class UsersTest extends TestBase
     public function testGetUserByGuidsThrowsExceptionWhenGuidsNotFound()
     {
         $this->setExpectedException('Exception', 'Error finding user profiles: Could not retrieve OAuth response code');
-        $mockClient = $this->getMock('Talis\Persona\Client\Users', ['performRequest'], [
+        $mockClient = $this->getMock(\Talis\Persona\Client\Users::class, ['performRequest'], [
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
@@ -114,7 +114,7 @@ class UsersTest extends TestBase
 
     public function testGetUserByGuidsReturnsUserWhenGuidsFound()
     {
-        $mockClient = $this->getMock('Talis\Persona\Client\Users', ['performRequest'], [
+        $mockClient = $this->getMock(\Talis\Persona\Client\Users::class, ['performRequest'], [
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
@@ -175,7 +175,7 @@ class UsersTest extends TestBase
 
     public function testCreateUserEmptyProfile()
     {
-        $mockClient = $this->getMock('Talis\Persona\Client\Users', ['performRequest'], [
+        $mockClient = $this->getMock(\Talis\Persona\Client\Users::class, ['performRequest'], [
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
@@ -218,7 +218,7 @@ class UsersTest extends TestBase
     public function testCreateUserPostFails()
     {
         $this->setExpectedException('Exception', 'Error creating user: Could not retrieve OAuth response code');
-        $mockClient = $this->getMock('Talis\Persona\Client\Users', ['performRequest'], [
+        $mockClient = $this->getMock(\Talis\Persona\Client\Users::class, ['performRequest'], [
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
@@ -233,7 +233,7 @@ class UsersTest extends TestBase
 
     public function testCreateUserPostSucceeds()
     {
-        $mockClient = $this->getMock('Talis\Persona\Client\Users', ['performRequest'], [
+        $mockClient = $this->getMock(\Talis\Persona\Client\Users::class, ['performRequest'], [
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
@@ -328,7 +328,7 @@ class UsersTest extends TestBase
     public function testUpdateUserPutFails()
     {
         $this->setExpectedException('Exception', 'Error updating user: Could not retrieve OAuth response code');
-        $mockClient = $this->getMock('Talis\Persona\Client\Users', ['performRequest'], [
+        $mockClient = $this->getMock(\Talis\Persona\Client\Users::class, ['performRequest'], [
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
@@ -343,7 +343,7 @@ class UsersTest extends TestBase
 
     public function testUpdateUserPutSucceeds()
     {
-        $mockClient = $this->getMock('Talis\Persona\Client\Users', ['performRequest'], [
+        $mockClient = $this->getMock(\Talis\Persona\Client\Users::class, ['performRequest'], [
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
@@ -412,7 +412,7 @@ class UsersTest extends TestBase
     public function testAddGupidToUserPatchFails()
     {
         $this->setExpectedException('Exception', 'Error adding gupid to user: Could not retrieve OAuth response code');
-        $mockClient = $this->getMock('Talis\Persona\Client\Users', ['performRequest'], [
+        $mockClient = $this->getMock(\Talis\Persona\Client\Users::class, ['performRequest'], [
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
@@ -427,7 +427,7 @@ class UsersTest extends TestBase
 
     public function testAddGupidToUserPutSucceeds()
     {
-        $mockClient = $this->getMock('Talis\Persona\Client\Users', ['performRequest'], [
+        $mockClient = $this->getMock(\Talis\Persona\Client\Users::class, ['performRequest'], [
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
@@ -496,7 +496,7 @@ class UsersTest extends TestBase
     public function testMergeUsersPostFails()
     {
         $this->setExpectedException('Exception', 'Error merging users: Could not retrieve OAuth response code');
-        $mockClient = $this->getMock('Talis\Persona\Client\Users', ['performRequest'], [
+        $mockClient = $this->getMock(\Talis\Persona\Client\Users::class, ['performRequest'], [
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',
@@ -511,7 +511,7 @@ class UsersTest extends TestBase
 
     public function testMergeUsersPostSucceeds()
     {
-        $mockClient = $this->getMock('Talis\Persona\Client\Users', ['performRequest'], [
+        $mockClient = $this->getMock(\Talis\Persona\Client\Users::class, ['performRequest'], [
             [
                 'userAgent' => 'unittest',
                 'persona_host' => 'localhost',


### PR DESCRIPTION
Referenced talis/platform#3484.

This PR changes HTTP client to [guzzlehttp/guzzle](https://packagist.org/packages/guzzlehttp/guzzle) (version 6) and removes [guzzle/guzzle](https://packagist.org/packages/guzzle/guzzle) (version 3) from dependencies. It does so in such way that there are no changes to code's behavior for consumers of the library.

However, it should be noted that there are significant differences between Guzzle 3 and 6, most notably in the latter request and reponse classes implement [PSR-7](https://www.php-fig.org/psr/psr-7/) interfaces and no longer have some helper methods such as [`isSuccessful()`](https://github.com/guzzle/guzzle/blob/v3.8.1/src/Guzzle/Http/Message/Response.php#L752) or [`__toString`](https://github.com/guzzle/guzzle/blob/v3.8.1/src/Guzzle/Http/Message/Response.php#L158), but instead the library no longer includes its own CA bundle, so the PHP settings for cURL extension are respected.

Unit tests that use mocked responses were completely refactored.