### PR TITLE
Ensure we are matching the full namespace, not just a prefix

### DIFF
--- a/src/Talis/Persona/Client/Login.php
+++ b/src/Talis/Persona/Client/Login.php
@@ -138,8 +138,9 @@ class Login extends Base
             // the prefix of the persona profile
             foreach ($_SESSION[self::LOGIN_PREFIX . ':loginSSO']['gupid'] as $gupid) {
                 $loginProvider = $_SESSION[self::LOGIN_PREFIX . ':loginProvider'];
-                if (strpos($gupid, $loginProvider) === 0) {
-                    return str_replace("$loginProvider:", '', $gupid);
+                $loginProviderNamespace = "$loginProvider:";
+                if (strpos($gupid, $loginProviderNamespace) === 0) {
+                    return str_replace($loginProviderNamespace, '', $gupid);
                 }
             }
         }

--- a/test/unit/Persona/LoginTest.php
+++ b/test/unit/Persona/LoginTest.php
@@ -502,6 +502,25 @@ class LoginTest extends TestBase
         $this->assertEquals('456', $personaClient->getPersistentId());
     }
 
+    public function testGetPersistentIdFoundMatchingGupidByFullNamespace()
+    {
+        $personaClient = new Login(
+            [
+                'userAgent' => 'unittest',
+                'persona_host' => 'localhost',
+                'cacheBackend' => $this->cacheBackend,
+            ]
+        );
+        $_SESSION[Login::LOGIN_PREFIX . ':loginProvider'] = 'google';
+        $_SESSION[Login::LOGIN_PREFIX . ':loginSSO'] = [
+            'gupid' => [
+                'google-with-suffix:456',
+                'google:123'
+            ]
+        ];
+        $this->assertEquals('123', $personaClient->getPersistentId());
+    }
+
     // getRedirectUrl tests
     public function testGetRedirectUrlNoSession()
     {


### PR DESCRIPTION
It looks like we have a bug in the code for extracting the persistent ID from the Persona login payload, whereby the persistent ID is drawn from the first GUPID to start with the provider, but we do not include the `:` to ensure we've actually hit a **full** match against the provider.

E.g. if I log in with a provider `google`, and my user has the following GUPIDs (in order):

* `google-plus:123`
* `google:456`

This would return `google-plus:123` as the persistent ID.

I do not know if we have this in the wild, because I just stumbled across it.  However, what you'd expect to see in this case is that the full persistent ID would be recorded for the user.  This is because we check that the string starts with the provider, but then remove the provider *and the colon*, which will not be present if we hit a prefix match only.

We should audit the application data in TARL to see if we have persistent IDs that contain complete GUPIDs.  I'm also a bit reluctant to release this unless we know the data are safe, because it will change behaviour for some users.