### PR TITLE
Add `Tokens::getSubjectIdFromToken`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "talis/talis-php",
   "description": "This is a php client library for talis APIs",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "keywords": [
     "persona",
     "echo",

--- a/src/Talis/Persona/Client/Tokens.php
+++ b/src/Talis/Persona/Client/Tokens.php
@@ -288,7 +288,7 @@ class Tokens extends Base
     }
 
     /**
-     * Extract the client ID (the `sub` claim) from a token.
+     * Extract the client ID for the Subject (the `sub` claim) from a token.
      * @param string $accessToken An access token (JWT)
      * @return string The client ID
      *
@@ -296,7 +296,7 @@ class Tokens extends Base
      * @throws InvalidTokenException If the token is valid, but contains no client ID
      * @throws \Exception If the token is invalid in other ways
      */
-    public function getClientIdFromToken($accessToken)
+    public function getSubjectIdFromToken($accessToken)
     {
         $clientId = $this->getClaimForToken($accessToken, 'sub');
         if (empty($clientId)) {

--- a/src/Talis/Persona/Client/Tokens.php
+++ b/src/Talis/Persona/Client/Tokens.php
@@ -288,6 +288,51 @@ class Tokens extends Base
     }
 
     /**
+     * Extract the client ID (the `sub` claim) from a token.
+     * @param string $accessToken An access token (JWT)
+     * @return string The client ID
+     *
+     * @throws TokenValidationException If the token is not a string
+     * @throws InvalidTokenException If the token is valid, but contains no client ID
+     * @throws \Exception If the token is invalid in other ways
+     */
+    public function getClientIdFromToken($accessToken)
+    {
+        $clientId = $this->getClaimForToken($accessToken, 'sub');
+        if (empty($clientId)) {
+            throw new InvalidTokenException('Decoded token contains no client ID');
+        }
+        return $clientId;
+    }
+
+    /**
+     * Extract a named claim from a token.
+     * @param string $accessToken An access token (JWT)
+     * @param string $claim A claim identifier
+     * @return string|null The claim value from the token, or `null` if unavailable.
+     *
+     * @throws TokenValidationException If the token is not a string
+     * @throws \InvalidArgumentException If the claim identifier is not a string
+     * @throws \Exception If the token is invalid in other ways
+     */
+    public function getClaimForToken($accessToken, $claim)
+    {
+        if (!is_string($accessToken)) {
+            throw new TokenValidationException('Access token is not a string');
+        }
+        if (!is_string($claim)) {
+            throw new \InvalidArgumentException('Claim is not a string');
+        }
+
+        $decodedToken = $this->decodeToken($accessToken, $this->retrieveJWTCertificate());
+
+        if (isset($decodedToken[$claim]) && is_string($decodedToken[$claim])) {
+            return $decodedToken[$claim];
+        }
+        return null;
+    }
+
+    /**
      * Checks the supplied config, verifies that all required parameters are present and
      * contain a non null value;
      *

--- a/test/unit/Persona/TokensTest.php
+++ b/test/unit/Persona/TokensTest.php
@@ -1386,23 +1386,21 @@ class TokensTest extends TestBase
     /**
      * Creates a fake JWT with realistic-looking claim data.
      *
-     * Note: if you supply the `sub` claim, be sure to add it to the `scopes` claim, and
-     * specify it as the `aud` claim (Persona assigns this to the client ID, incorrectly).
-     *
      * @param array $claims An array of JWT claims.
      * @return string An encoded JWT encapsulating the specified claims
      */
     private function getFakeJWT(array $claims = [])
     {
         $now = time();
-        $fakeClientId = "fake-client-id-{$now}";
+        $fakeSubjectClientId = "fake-sub-client-id-{$now}";
+        $fakeAudienceClientId = "fake-aud-client-id-{$now}";
         $defaultClaims = [
-            'aud' => $fakeClientId, // this is what Persona does, rather than what it *should* do
+            'aud' => $fakeAudienceClientId,
             'exp' => $now + 100,
             'iat' => $now,
             'jti' => $now,
-            'scopes' => [$fakeClientId],
-            'sub' => $fakeClientId
+            'scopes' => [$fakeSubjectClientId],
+            'sub' => $fakeSubjectClientId
         ];
         $claimsWithDefaults = array_merge($defaultClaims, $claims);
         return JWT::encode($claimsWithDefaults, $this->privateKey, 'RS256');

--- a/test/unit/Persona/TokensTest.php
+++ b/test/unit/Persona/TokensTest.php
@@ -1310,6 +1310,38 @@ class TokensTest extends TestBase
     }
 
     /**
+     * @covers Tokens::getClientIdFromToken
+     */
+    public function testGetClientIdFromTokenReturnsClientIdFromToken()
+    {
+        $mockClient = $this->getMockTokensClientWithFakeCertificate();
+
+        $fakeClientId = 'this-is-a-fake-client-id';
+        $accessToken = $this->getFakeJWT([
+            'sub' => $fakeClientId,
+            'scopes' => [$fakeClientId]
+        ]);
+
+        $clientIdFromToken = $mockClient->getClientIdFromToken($accessToken);
+        $this->assertEquals($fakeClientId, $clientIdFromToken);
+    }
+
+    /**
+     * @covers Tokens::getClientIdFromToken
+     */
+    public function testGetClientIdFromTokenThrowsExceptionIfTokenContainsNoSubClaim()
+    {
+        $mockClient = $this->getMockTokensClientWithFakeCertificate();
+
+        $accessToken = $this->getFakeJWT([
+            'sub' => null
+        ]);
+
+        $this->setExpectedException(InvalidTokenException::class);
+        $mockClient->getClientIdFromToken($accessToken);
+    }
+
+    /**
      * Gets the client with mocked HTTP responses.
      *
      * @param \GuzzleHttp\Psr7\Response[] $responses The responses
@@ -1322,5 +1354,57 @@ class TokensTest extends TestBase
         $httpClient = new \GuzzleHttp\Client(['handler' => $handlerStack]);
 
         return $httpClient;
+    }
+
+    /**
+     * Create a mock `Tokens` client, with the cache backend and certificate defined in instance variables
+     * for this class.
+     * @return \Talis\Persona\Client\Tokens
+     */
+    private function getMockTokensClientWithFakeCertificate()
+    {
+        /** @var \Talis\Persona\Client\Tokens|\PHPUnit_Framework_MockObject_MockObject $mockClient */
+        $mockClient = $this->getMock(
+            \Talis\Persona\Client\Tokens::class,
+            ['retrieveJWTCertificate'],
+            [
+                [
+                    'userAgent' => 'unittest',
+                    'persona_host' => 'localhost',
+                    'cacheBackend' => $this->cacheBackend,
+                ]
+            ]
+        );
+
+        $mockClient->expects($this->once())
+            ->method('retrieveJWTCertificate')
+            ->willReturn($this->publicKey);
+
+        return $mockClient;
+    }
+
+    /**
+     * Creates a fake JWT with realistic-looking claim data.
+     *
+     * Note: if you supply the `sub` claim, be sure to add it to the `scopes` claim, and
+     * specify it as the `aud` claim (Persona assigns this to the client ID, incorrectly).
+     *
+     * @param array $claims An array of JWT claims.
+     * @return string An encoded JWT encapsulating the specified claims
+     */
+    private function getFakeJWT(array $claims = [])
+    {
+        $now = time();
+        $fakeClientId = "fake-client-id-{$now}";
+        $defaultClaims = [
+            'aud' => $fakeClientId, // this is what Persona does, rather than what it *should* do
+            'exp' => $now + 100,
+            'iat' => $now,
+            'jti' => $now,
+            'scopes' => [$fakeClientId],
+            'sub' => $fakeClientId
+        ];
+        $claimsWithDefaults = array_merge($defaultClaims, $claims);
+        return JWT::encode($claimsWithDefaults, $this->privateKey, 'RS256');
     }
 }

--- a/test/unit/Persona/TokensTest.php
+++ b/test/unit/Persona/TokensTest.php
@@ -1310,9 +1310,9 @@ class TokensTest extends TestBase
     }
 
     /**
-     * @covers Tokens::getClientIdFromToken
+     * @covers Tokens::getSubjectIdFromToken
      */
-    public function testGetClientIdFromTokenReturnsClientIdFromToken()
+    public function testgetSubjectIdFromTokenReturnsClientIdFromToken()
     {
         $mockClient = $this->getMockTokensClientWithFakeCertificate();
 
@@ -1322,14 +1322,14 @@ class TokensTest extends TestBase
             'scopes' => [$fakeClientId]
         ]);
 
-        $clientIdFromToken = $mockClient->getClientIdFromToken($accessToken);
+        $clientIdFromToken = $mockClient->getSubjectIdFromToken($accessToken);
         $this->assertEquals($fakeClientId, $clientIdFromToken);
     }
 
     /**
-     * @covers Tokens::getClientIdFromToken
+     * @covers Tokens::getSubjectIdFromToken
      */
-    public function testGetClientIdFromTokenThrowsExceptionIfTokenContainsNoSubClaim()
+    public function testgetSubjectIdFromTokenThrowsExceptionIfTokenContainsNoSubClaim()
     {
         $mockClient = $this->getMockTokensClientWithFakeCertificate();
 
@@ -1338,7 +1338,7 @@ class TokensTest extends TestBase
         ]);
 
         $this->setExpectedException(InvalidTokenException::class);
-        $mockClient->getClientIdFromToken($accessToken);
+        $mockClient->getSubjectIdFromToken($accessToken);
     }
 
     /**

--- a/test/unit/Persona/TokensTest.php
+++ b/test/unit/Persona/TokensTest.php
@@ -1312,7 +1312,7 @@ class TokensTest extends TestBase
     /**
      * @covers Tokens::getSubjectIdFromToken
      */
-    public function testgetSubjectIdFromTokenReturnsClientIdFromToken()
+    public function testGetSubjectIdFromTokenReturnsClientIdFromToken()
     {
         $mockClient = $this->getMockTokensClientWithFakeCertificate();
 
@@ -1329,7 +1329,7 @@ class TokensTest extends TestBase
     /**
      * @covers Tokens::getSubjectIdFromToken
      */
-    public function testgetSubjectIdFromTokenThrowsExceptionIfTokenContainsNoSubClaim()
+    public function testGetSubjectIdFromTokenThrowsExceptionIfTokenContainsNoSubClaim()
     {
         $mockClient = $this->getMockTokensClientWithFakeCertificate();
 


### PR DESCRIPTION
Add `Tokens::getSubjectIdFromToken` method for extracting the principal subject's client ID from a token

Persona tokens include a `sub` claim, which identifies the client to whom the token belongs.  This adds a method to get the client ID from an access token.