### PR TITLE
PLAT-3846 re-work development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.phar
 build
 vendor
 docker-compose.override.yml
+.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,24 @@
-services:
-- redis-server
-sudo: false
 language: php
 dist: trusty
+sudo: false
 addons:
   apt:
-    packages:
-      ant
+    packages: ant
 php:
-- 7.3
-- 7.2
-- 7.1
-- 7.0
-- 5.6
-- 5.5
+  - 7.3
+  - 7.2
+  - 7.1
+  - 7.0
+  - 5.6
+  - 5.5
 install:
-- composer install
+  - composer install
 script: |
-    set -xe
-    ant lint
-    ant test
-notifications:
-  hipchat:
-    rooms:
-      secure: XVGvIN4wW6po+uYi7G3jip5e7Jo5um/eEz7GDNxkNGfKuMhaq1NF/U14ngOK38zM20MLXDForSb6HDJhdDScLdVV42EWZmb0bYp58uy1+dvQTzDzmnKzugw4UKpPhr6932msiB+T5/Ss5iEd/A4RaRsHBC8jgRVNKLnZ5rcb3ao=
+  set -xe
+  ant lint
+  ant test
 env:
   global:
-  - PERSONA_TEST_HOST: https://staging-users.talis.com
-  - secure: P6xLcE2Iy4OS47ZS4v2I3C7LUsXMH8vYiJ+B3lX/KCWF5xunHYfj+mbVlMXRyyPANP0SZgIwaobSvyP2+xpv7MTSo9TWMYNR6WaLcF65QlU/rnnl2UBTrBGQI7jAUeLqPpG2xB9ZkCoR+6r53uKRwbgOVA88ibp8iXAao0LQ7d2Cf40ddyGsaoauQg3heVT/V9KwXmf6mvbVSYMLatY4SN8ElZRy5cFF843JKX+7RMs8Zb7o2hTHoE3rFvsqhnb0zCUjo3iwVsUWI/C+yySSxiwzw1vBaR6uEe7Kkr2FxICh8avRJjP7qpM3jiyKmX/PG7mBfqOtWjyRoA7jgEa+hFksXGL4U6656wx9SMFY8NvvxZ42M7EdUfwGM7XDj4vcSP2JK+AY0wdUOjxVstIiHrcIJE4WZ8DVg1hiqAvmT6V1WpEpQ8Ph/FgdLAL9ZtkTsxFfJFve0kaAOQXfY13CgXHeGUZTtzVKZKyBzRy/MzewJUqWXtzEuRIhyLwEIsIqr7leXpf5p7iw355luV9junLcED9zlJQDL1dZ4/CjE7317FkqgR0saCaCuh0Ujjgm3+hXg/a0VT09HddU5NnlgYwmZreNB9y1FpLzzWOXjvxrllJjjBrfarhcO166rsoGyaHMFJWgXXBBaHHLlnvuTVoDlmaR7IMFynA9U9G93LU=
-  - secure: fgeHTrQLww8MJKY6di9y8bDu/xdNJmvC0aTN3Kz3Uu/y/96RvnFd+b11UBd2AGzaNjKGCXSs5GlZPWd9tq4z2waCQ1CPEOlZOLDgXu/alQcngyu7DOPGBoHgFlbnMZGatTnvaD56e04pu+fp7CLcjRXQOQbTWbietb2VotIVIxJB/sne1ycaqhBeBhXOWs3i9M7vq6XGjHp658MuW9fDo/b3UHf9DAJku6yFjjGOFE6dEsNb1cYaoTxi0j/ELnoVXEUXmZTW1ZcFDQXIA4gWH93BQqC4oMHwj30otUWoItVIUZq9OyaaTGH3pBlW/doOwpvtVXoheNpRyWdLlqz5do7vbY5EpWPm1Is68Y5eKbrawfhRE+T+OSTGaPDW9wl77pxU7PzLrq4ZhH4P5g+K2HAdaEAiSMugtQrx5tmLq4UwHDzgB8RN3ZHaqC5AgqL+x1hQG7YTz+EJENGOTVhOZLhUZJFQC0flLY5WJIjZMTZL9UWq6h41d7x/xUk0njpptRBFKBH4sg9t0T/lbXpDheOV5mV1eyLYuSDczjhs7HsrvSWaKSU0pE9LVdlLMPFK0QdiPUjIxp5nmG3fQjBuhiCKpN38ZcPzEoA4g45SfAdkeh9hjB2g0xn2UcXMQV+ILnNKhuZUmMJ9DECT6BVCdV3svVfm+ZRbDAjfZzuSYvo=
+    - PERSONA_TEST_HOST: https://staging-users.talis.com
+    - secure: P6xLcE2Iy4OS47ZS4v2I3C7LUsXMH8vYiJ+B3lX/KCWF5xunHYfj+mbVlMXRyyPANP0SZgIwaobSvyP2+xpv7MTSo9TWMYNR6WaLcF65QlU/rnnl2UBTrBGQI7jAUeLqPpG2xB9ZkCoR+6r53uKRwbgOVA88ibp8iXAao0LQ7d2Cf40ddyGsaoauQg3heVT/V9KwXmf6mvbVSYMLatY4SN8ElZRy5cFF843JKX+7RMs8Zb7o2hTHoE3rFvsqhnb0zCUjo3iwVsUWI/C+yySSxiwzw1vBaR6uEe7Kkr2FxICh8avRJjP7qpM3jiyKmX/PG7mBfqOtWjyRoA7jgEa+hFksXGL4U6656wx9SMFY8NvvxZ42M7EdUfwGM7XDj4vcSP2JK+AY0wdUOjxVstIiHrcIJE4WZ8DVg1hiqAvmT6V1WpEpQ8Ph/FgdLAL9ZtkTsxFfJFve0kaAOQXfY13CgXHeGUZTtzVKZKyBzRy/MzewJUqWXtzEuRIhyLwEIsIqr7leXpf5p7iw355luV9junLcED9zlJQDL1dZ4/CjE7317FkqgR0saCaCuh0Ujjgm3+hXg/a0VT09HddU5NnlgYwmZreNB9y1FpLzzWOXjvxrllJjjBrfarhcO166rsoGyaHMFJWgXXBBaHHLlnvuTVoDlmaR7IMFynA9U9G93LU=
+    - secure: fgeHTrQLww8MJKY6di9y8bDu/xdNJmvC0aTN3Kz3Uu/y/96RvnFd+b11UBd2AGzaNjKGCXSs5GlZPWd9tq4z2waCQ1CPEOlZOLDgXu/alQcngyu7DOPGBoHgFlbnMZGatTnvaD56e04pu+fp7CLcjRXQOQbTWbietb2VotIVIxJB/sne1ycaqhBeBhXOWs3i9M7vq6XGjHp658MuW9fDo/b3UHf9DAJku6yFjjGOFE6dEsNb1cYaoTxi0j/ELnoVXEUXmZTW1ZcFDQXIA4gWH93BQqC4oMHwj30otUWoItVIUZq9OyaaTGH3pBlW/doOwpvtVXoheNpRyWdLlqz5do7vbY5EpWPm1Is68Y5eKbrawfhRE+T+OSTGaPDW9wl77pxU7PzLrq4ZhH4P5g+K2HAdaEAiSMugtQrx5tmLq4UwHDzgB8RN3ZHaqC5AgqL+x1hQG7YTz+EJENGOTVhOZLhUZJFQC0flLY5WJIjZMTZL9UWq6h41d7x/xUk0njpptRBFKBH4sg9t0T/lbXpDheOV5mV1eyLYuSDczjhs7HsrvSWaKSU0pE9LVdlLMPFK0QdiPUjIxp5nmG3fQjBuhiCKpN38ZcPzEoA4g45SfAdkeh9hjB2g0xn2UcXMQV+ILnNKhuZUmMJ9DECT6BVCdV3svVfm+ZRbDAjfZzuSYvo=

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,49 +2,22 @@ FROM talis/ubuntu:1404-latest
 
 ENV DEBIAN_FRONTEND noninteractive
 
-ARG persona_oauth_client
-ARG persona_oauth_secret
-
-RUN apt-get update \
-    && apt-get install -y --force-yes curl apt-transport-https \
-    && curl -L http://apt.talis.com:81/public.key | sudo apt-key add - \
-    && apt-get update \
-    && apt-get upgrade -y
+ENV COMPOSER_ALLOW_SUPERUSER=1
+ENV COMPOSER_HOME=/tmp
 
 # Install php and ant
-RUN apt-get install --no-install-recommends -y \
-		curl ca-certificates \
-		php5-cli \
-		php5-dev \
-		php5-xdebug \
-		php5-curl \
-		php5-json \
-		php-pear \
-    ant \
-    git
-
-# Install redis and cli, staring the service
-RUN apt-get install --no-install-recommends -y \
-    redis-tools \
-    redis-server
-
-# Install composer
-RUN curl https://getcomposer.org/installer | php -- && mv composer.phar /usr/local/bin/composer && chmod +x /usr/local/bin/composer
-
-# Tidy up
-RUN apt-get -y autoremove && apt-get clean && apt-get autoclean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-RUN mkdir -p /var/talis-php
-COPY . /var/talis-php
-
-RUN echo "export PERSONA_TEST_HOST='http://persona.talis.local'" >> /etc/profile.d/test.sh \
-    && echo "export PERSONA_TEST_OAUTH_CLIENT='$persona_oauth_client'" >> /etc/profile.d/test.sh \
-    && echo "export PERSONA_TEST_OAUTH_SECRET='$persona_oauth_secret'" >> /etc/profile.d/test.sh \
-    && chmod 775 /etc/profile.d/test.sh
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        curl ca-certificates \
+        php5-cli \
+        php5-dev \
+        php5-xdebug \
+        php5-curl \
+        php5-json \
+        php-pear \
+        ant \
+        git \
+        unzip \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 WORKDIR /var/talis-php
-
-RUN ant init
-
-CMD /bin/bash -c "service redis-server start && source /etc/profile.d/* && ant test"

--- a/build.xml
+++ b/build.xml
@@ -21,9 +21,6 @@
         <delete dir="${build.dir}"/>
         <mkdir dir="${build.dir}"/>
         <mkdir dir="${coverage.dir}"/>
-        <exec executable="redis-cli" failonerror="true">
-            <arg line="-n 2 flushdb"/>
-        </exec>
     </target>
 
     <target name="init" depends="install-composer"
@@ -87,26 +84,8 @@
 
     <target name="integrationtest" depends="clean">
         <exec executable="${vendor.dir}/bin/phpunit" failonerror="true">
-            <env key="PERSONA_TEST_HOST" value="${env.PERSONA_TEST_HOST}" />
-            <env key="PERSONA_TEST_OAUTH_CLIENT" value="${env.PERSONA_TEST_OAUTH_CLIENT}" />
-            <env key="PERSONA_TEST_OAUTH_SECRET" value="${env.PERSONA_TEST_OAUTH_SECRET}" />
             <arg line="${integration.test.dir}"/>
             <arg line="--log-junit ${build.dir}/integrationtest-report.xml"/>
-        </exec>
-    </target>
-
-    <target name="build">
-        <exec executable="/usr/bin/docker" failonerror="true">
-            <arg value="build" />
-            <arg value="-t" />
-            <arg value="talis/talis-php" />
-            <arg value="--build-arg" />
-            <arg value="git_oauth_token=${env.git_oauth_token}" />
-            <arg value="--build-arg" />
-            <arg value="persona_oauth_client=${env.persona_oauth_client}" />
-            <arg value="--build-arg" />
-            <arg value="persona_oauth_secret=${env.persona_oauth_secret}" />
-            <arg value="." />
         </exec>
     </target>
 </project>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ x-common-values: &common-values
     network: host
   environment:
     PERSONA_TEST_HOST: ${PERSONA_TEST_HOST:-http://persona.talis.local}
-    PERSONA_TEST_OAUTH_CLIENT: ${PERSONA_OAUTH_CLIENT:?required}
-    PERSONA_TEST_OAUTH_SECRET: ${PERSONA_OAUTH_SECRET:?required}
+    PERSONA_TEST_OAUTH_CLIENT: ${PERSONA_TEST_OAUTH_CLIENT:-primate}
+    PERSONA_TEST_OAUTH_SECRET: ${PERSONA_TEST_OAUTH_SECRET:-bananas}
   volumes:
     - ".:/var/talis-php"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,53 +1,54 @@
-version: '2'
+version: "3.7"
+
+x-common-values: &common-values
+  image: talis/talis-php
+  network_mode: host
+  build:
+    context: .
+    network: host
+  environment:
+    PERSONA_TEST_HOST: ${PERSONA_TEST_HOST:-http://persona.talis.local}
+    PERSONA_TEST_OAUTH_CLIENT: ${PERSONA_OAUTH_CLIENT:?required}
+    PERSONA_TEST_OAUTH_SECRET: ${PERSONA_OAUTH_SECRET:?required}
+  volumes:
+    - ".:/var/talis-php"
 
 services:
   init:
-    image: talis/talis-php
-    volumes:
-      - ".:/var/talis-php"
-    command: /bin/bash -c "service redis-server start && source /etc/profile.d/* && ant init"
+    <<: *common-values
+    command: "ant init"
+
   lint:
-    image: talis/talis-php
-    volumes:
-      - ".:/var/talis-php"
-    command: /bin/bash -c "service redis-server start && source /etc/profile.d/* && ant lint"
-  lint-stan:
-    image: phpstan/phpstan
-    volumes:
-      - ".:/app"
-    command: 'analyse /app'
-  codecheck:
-    image: talis/talis-php
-    volumes:
-      - ".:/var/talis-php"
-    command: /bin/bash -c "service redis-server start && source /etc/profile.d/* && ant code-check"
+    <<: *common-values
+    command: "ant lint"
+
+  code-check:
+    <<: *common-values
+    command: "ant code-check"
+
   test:
-    image: talis/talis-php
-    network_mode: host
-    volumes:
-      - ".:/var/talis-php"
-    command: /bin/bash -c "service redis-server start && source /etc/profile.d/* && ant test"
+    <<: *common-values
+    command: "ant test"
+
   unittest:
-    image: talis/talis-php
-    network_mode: host
-    volumes:
-      - ".:/var/talis-php"
-    command: /bin/bash -c "service redis-server start && source /etc/profile.d/* && ant unittest"
+    <<: *common-values
+    command: "ant unittest"
+
   integrationtest:
-    image: talis/talis-php
-    network_mode: host
-    volumes:
-      - ".:/var/talis-php"
-    command: /bin/bash -c "service redis-server start && source /etc/profile.d/* && ant integrationtest"
+    <<: *common-values
+    command: "ant integrationtest"
+
   local-dev:
-    image: talis/talis-php
-    network_mode: host
-    volumes:
-      - ".:/var/talis-php"
-    command: /bin/bash
+    <<: *common-values
+    command: "/bin/bash"
+
   coverage:
-    image: talis/talis-php
-    network_mode: host
+    <<: *common-values
+    command: "ant coverage"
+
+  analyse:
+    image: phpstan/phpstan:0.12.40
     volumes:
       - ".:/var/talis-php"
-    command: /bin/bash -c "service redis-server start && source /etc/profile.d/* && ant coverage"
+    working_dir: /var/talis-php
+    command: "analyse src"


### PR DESCRIPTION
References talis/platform#3846.

- Update docker-compose file to 3.7
- Remove redis-server as it's not used by tests
- Use docker-compose `build` to build the dev image
- Move PERSONA_OAUTH_* variables to .env file
- Remove hipchat from Travis config