### PR TITLE
PLAT-3846 fix Critic client

### DIFF
--- a/src/Talis/Critic/Client.php
+++ b/src/Talis/Critic/Client.php
@@ -148,7 +148,7 @@ class Client
         );
 
         return [
-            'Content-Type' => 'application/json',
+            'Content-Type' => 'application/x-www-form-urlencoded; charset=utf-8',
             'Authorization' => "Bearer {$token['access_token']}",
         ];
     }


### PR DESCRIPTION
References talis/platform#3846.

- Fix the POST request in Critic client to send correct Content-Type header.
- Update the test and ensure the request is urlencoded.