### PR TITLE
PLAT-3884 Add extra logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ php:
   - 5.6
   - 5.5
 install:
+  - composer self-update
   - composer install
 script: |
   set -xe

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "talis/talis-php",
   "description": "This is a php client library for talis APIs",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "keywords": [
     "persona",
     "echo",

--- a/src/Talis/Persona/Client/Login.php
+++ b/src/Talis/Persona/Client/Login.php
@@ -81,19 +81,19 @@ class Login extends Base
 
         if (!isset($_SESSION[self::LOGIN_PREFIX . ':loginState'])) {
             $this->getLogger()->error('Login state not found on Session');
-            throw new \Exception('Login state does not match');
+            throw new \Exception('Login state does not match (LS01)');
         }
 
         if (!isset($payload['state'])) {
             $this->getLogger()->error('Payload does not contain login state');
             unset($_SESSION[self::LOGIN_PREFIX . ':loginState']);
-            throw new \Exception('Login state does not match');
+            throw new \Exception('Login state does not match (LS02)');
         }
 
         if ($payload['state'] !== $_SESSION[self::LOGIN_PREFIX . ':loginState']) {
             $this->getLogger()->error('Session login state does not match payload state');
             unset($_SESSION[self::LOGIN_PREFIX . ':loginState']);
-            throw new \Exception('Login state does not match');
+            throw new \Exception('Login state does not match (LS03)');
         }
 
         $signature = hash_hmac(

--- a/src/Talis/Persona/Client/Login.php
+++ b/src/Talis/Persona/Client/Login.php
@@ -81,19 +81,19 @@ class Login extends Base
 
         if (!isset($_SESSION[self::LOGIN_PREFIX . ':loginState'])) {
             $this->getLogger()->error('Login state not found on Session');
-            throw new \Exception('Login state does not match (LS01)');
+            throw new \Exception('Login state does not match');
         }
 
         if (!isset($payload['state'])) {
             $this->getLogger()->error('Payload does not contain login state');
             unset($_SESSION[self::LOGIN_PREFIX . ':loginState']);
-            throw new \Exception('Login state does not match (LS02)');
+            throw new \Exception('Login state does not match');
         }
 
         if ($payload['state'] !== $_SESSION[self::LOGIN_PREFIX . ':loginState']) {
             $this->getLogger()->error('Session login state does not match payload state');
             unset($_SESSION[self::LOGIN_PREFIX . ':loginState']);
-            throw new \Exception('Login state does not match (LS03)');
+            throw new \Exception('Login state does not match');
         }
 
         $signature = hash_hmac(

--- a/src/Talis/Persona/Client/Login.php
+++ b/src/Talis/Persona/Client/Login.php
@@ -79,13 +79,19 @@ class Login extends Base
             throw new \Exception('Payload not json');
         }
 
-        if (
-            !isset($_SESSION[self::LOGIN_PREFIX . ':loginState'])
-            || !isset($payload['state'])
-            || $payload['state'] !== $_SESSION[self::LOGIN_PREFIX . ':loginState']
-        ) {
-            // Error with state - not authenticated
-            $this->getLogger()->error('Login state does not match');
+        if (!isset($_SESSION[self::LOGIN_PREFIX . ':loginState'])) {
+            $this->getLogger()->error('Login state not found on Session');
+            throw new \Exception('Login state does not match');
+        }
+
+        if (!isset($payload['state'])) {
+            $this->getLogger()->error('Payload does not contain login state');
+            unset($_SESSION[self::LOGIN_PREFIX . ':loginState']);
+            throw new \Exception('Login state does not match');
+        }
+
+        if ($payload['state'] !== $_SESSION[self::LOGIN_PREFIX . ':loginState']) {
+            $this->getLogger()->error('Session login state does not match payload state');
             unset($_SESSION[self::LOGIN_PREFIX . ':loginState']);
             throw new \Exception('Login state does not match');
         }

--- a/test/unit/Persona/LoginTest.php
+++ b/test/unit/Persona/LoginTest.php
@@ -190,7 +190,7 @@ class LoginTest extends TestBase
 
     public function testValidateAuthThrowsExceptionWhenPayloadIsMissingState()
     {
-        $this->setExpectedException('Exception', 'Login state does not match (LS02)');
+        $this->setExpectedException('Exception', 'Login state does not match');
         $personaClient = new Login(
             [
                 'userAgent' => 'unittest',
@@ -206,7 +206,7 @@ class LoginTest extends TestBase
 
     public function testValidateAuthThrowsExceptionWhenSessionIsMissingState()
     {
-        $this->setExpectedException('Exception', 'Login state does not match (LS01)');
+        $this->setExpectedException('Exception', 'Login state does not match');
         $personaClient = new Login(
             [
                 'userAgent' => 'unittest',
@@ -225,7 +225,7 @@ class LoginTest extends TestBase
 
     public function testValidateAuthThrowsExceptionWhenSessionStateDoNotMatchPayloadState()
     {
-        $this->setExpectedException('Exception', 'Login state does not match (LS03)');
+        $this->setExpectedException('Exception', 'Login state does not match');
         $personaClient = new Login(
             [
                 'userAgent' => 'unittest',

--- a/test/unit/Persona/LoginTest.php
+++ b/test/unit/Persona/LoginTest.php
@@ -190,7 +190,7 @@ class LoginTest extends TestBase
 
     public function testValidateAuthThrowsExceptionWhenPayloadIsMissingState()
     {
-        $this->setExpectedException('Exception', 'Login state does not match');
+        $this->setExpectedException('Exception', 'Login state does not match (LS02)');
         $personaClient = new Login(
             [
                 'userAgent' => 'unittest',
@@ -201,6 +201,44 @@ class LoginTest extends TestBase
         $_SESSION[Login::LOGIN_PREFIX . ':loginState'] = 'Tennessee';
         $_POST['persona:signature'] = 'DummySignature';
         $_POST['persona:payload'] = base64_encode(json_encode(['test' => 'YouShallNotPass']));
+        $personaClient->validateAuth();
+    }
+
+    public function testValidateAuthThrowsExceptionWhenSessionIsMissingState()
+    {
+        $this->setExpectedException('Exception', 'Login state does not match (LS01)');
+        $personaClient = new Login(
+            [
+                'userAgent' => 'unittest',
+                'persona_host' => 'localhost',
+                'cacheBackend' => $this->cacheBackend,
+            ]
+        );
+        $_SESSION = [];
+        $_POST['persona:signature'] = 'DummySignature';
+        $_POST['persona:payload'] = base64_encode(json_encode([
+            'test' => 'YouShallNotPass',
+            'state' => 'Tennessee'
+        ]));
+        $personaClient->validateAuth();
+    }
+
+    public function testValidateAuthThrowsExceptionWhenSessionStateDoNotMatchPayloadState()
+    {
+        $this->setExpectedException('Exception', 'Login state does not match (LS03)');
+        $personaClient = new Login(
+            [
+                'userAgent' => 'unittest',
+                'persona_host' => 'localhost',
+                'cacheBackend' => $this->cacheBackend,
+            ]
+        );
+        $_SESSION[Login::LOGIN_PREFIX . ':loginState'] = 'Alabama';
+        $_POST['persona:signature'] = 'DummySignature';
+        $_POST['persona:payload'] = base64_encode(json_encode([
+            'test' => 'YouShallNotPass',
+            'state' => 'Tennessee'
+        ]));
         $personaClient->validateAuth();
     }
 

--- a/test/unit/Persona/LoginTest.php
+++ b/test/unit/Persona/LoginTest.php
@@ -214,6 +214,7 @@ class LoginTest extends TestBase
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
+
         $_SESSION = [];
         $_POST['persona:signature'] = 'DummySignature';
         $_POST['persona:payload'] = base64_encode(json_encode([

--- a/test/unit/Persona/LoginTest.php
+++ b/test/unit/Persona/LoginTest.php
@@ -214,7 +214,6 @@ class LoginTest extends TestBase
                 'cacheBackend' => $this->cacheBackend,
             ]
         );
-
         $_SESSION = [];
         $_POST['persona:signature'] = 'DummySignature';
         $_POST['persona:payload'] = base64_encode(json_encode([


### PR DESCRIPTION
This P/R changes the `Login::validateAuth()` method to break up the following compound check into a series of discrete checks:

```php
if (
            !isset($_SESSION[self::LOGIN_PREFIX . ':loginState'])
            || !isset($payload['state'])
            || $payload['state'] !== $_SESSION[self::LOGIN_PREFIX . ':loginState']
   ) {
 ...
}
```

This is so we can add more detailed logging around each of these to aid in debugging login issues.

I've also added more testing around the validateAuth() method to improve the coverage.
