### PR TITLE
TA-2315: Upgrade php-jwt to version 6.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,6 @@ workflows:
           matrix:
             parameters:
               php_version:
-                - 5.6.40
                 - 7.4.33
                 - 8.0.30
                 - 8.1.29

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "ext-hash": "*",
     "ext-openssl": "*",
     "doctrine/common": "^2.5",
-    "firebase/php-jwt": "6.2",
+    "firebase/php-jwt": "^6.2",
     "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5",
     "monolog/monolog": ">=1.13.1",
     "predis/predis": ">=0.8.5",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "ext-hash": "*",
     "ext-openssl": "*",
     "doctrine/common": "^2.5",
-    "firebase/php-jwt": "^6.0",
+    "firebase/php-jwt": "6.2",
     "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5",
     "monolog/monolog": ">=1.13.1",
     "predis/predis": ">=0.8.5",


### PR DESCRIPTION
To allow the https://github.com/techfromsage/lti-1-3-php-library to be installed alongside this library, we need to update `firebase/php-jwt` to version `6.2`.

PHP 5.X support was removed from `firebase/php-jwt` in version `6.1` so we will have to remove support for php 5.X for this library moving forwards.