### PR TITLE
TA-3547 - Add retry middleware to the various Guzzle clients

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "talis/talis-php",
   "description": "This is a php client library for talis APIs",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "keywords": [
     "persona",
     "echo",

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     "php": ">=7.3",
     "ext-hash": "*",
     "ext-openssl": "*",
+    "caseyamcl/guzzle_retry_middleware": "^2.13",
     "doctrine/common": "^2.5",
     "firebase/php-jwt": "^6.2 || ^7.0",
     "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5",

--- a/src/Talis/Babel/Client.php
+++ b/src/Talis/Babel/Client.php
@@ -2,6 +2,8 @@
 
 namespace Talis\Babel;
 
+use GuzzleHttp\HandlerStack;
+use GuzzleRetry\GuzzleRetryMiddleware;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Psr\Log\LoggerAwareInterface;
@@ -415,7 +417,19 @@ class Client implements LoggerAwareInterface
                 $baseUrl .= ":$port";
             }
 
-            $this->httpClient = new \GuzzleHttp\Client(['base_uri' => $baseUrl]);
+            // Using the default values of https://github.com/caseyamcl/guzzle_retry_middleware.
+            // Will trap 429 & 503 errors and retry (honouring `RetryAfter` header for 429's).
+            $stack = HandlerStack::create();
+            $stack->push(GuzzleRetryMiddleware::factory([
+                'on_retry_callback' => function ($attemptNumber, $delay) {
+                    $this->getLogger()->warning("Babel retry #{$attemptNumber} after {$delay}s delay");
+                }
+            ]));
+
+            $this->httpClient = new \GuzzleHttp\Client([
+                'base_uri' => $baseUrl,
+                'handler' => $stack
+            ]);
         }
 
         return $this->httpClient;

--- a/src/Talis/Critic/Client.php
+++ b/src/Talis/Critic/Client.php
@@ -2,6 +2,9 @@
 
 namespace Talis\Critic;
 
+use GuzzleHttp\HandlerStack;
+use GuzzleRetry\GuzzleRetryMiddleware;
+
 class Client
 {
     protected $clientId;
@@ -77,7 +80,14 @@ class Client
     protected function getHTTPClient()
     {
         if (!$this->httpClient) {
-            $this->httpClient = new \GuzzleHttp\Client();
+            // Using the default values of https://github.com/caseyamcl/guzzle_retry_middleware.
+            // Will trap 429 & 503 errors and retry (honouring `RetryAfter` header for 429's).
+            $stack = HandlerStack::create();
+            $stack->push(GuzzleRetryMiddleware::factory());
+
+            $this->httpClient = new \GuzzleHttp\Client([
+                'handler' => $stack
+            ]);
         }
 
         return $this->httpClient;

--- a/src/Talis/EchoClient/Base.php
+++ b/src/Talis/EchoClient/Base.php
@@ -2,6 +2,8 @@
 
 namespace Talis\EchoClient;
 
+use GuzzleHttp\HandlerStack;
+use GuzzleRetry\GuzzleRetryMiddleware;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 
@@ -81,7 +83,18 @@ abstract class Base
      */
     protected function getHttpClient()
     {
-        return new \GuzzleHttp\Client();
+        // Using the default values of https://github.com/caseyamcl/guzzle_retry_middleware.
+        // Will trap 429 & 503 errors and retry (honouring `RetryAfter` header for 429's).
+        $stack = HandlerStack::create();
+        $stack->push(GuzzleRetryMiddleware::factory([
+            'on_retry_callback' => function ($attemptNumber, $delay) {
+                $this->getLogger()->warning("Echo retry #{$attemptNumber} after {$delay}s delay");
+            }
+        ]));
+
+        return new \GuzzleHttp\Client([
+            'handler' => $stack
+        ]);
     }
 
     /**

--- a/src/Talis/Manifesto/Client.php
+++ b/src/Talis/Manifesto/Client.php
@@ -2,6 +2,9 @@
 
 namespace Talis\Manifesto;
 
+use GuzzleHttp\HandlerStack;
+use GuzzleRetry\GuzzleRetryMiddleware;
+
 // phpcs:disable PSR1.Files.SideEffects
 require_once 'common.inc.php';
 
@@ -92,7 +95,14 @@ class Client
     protected function getHTTPClient()
     {
         if (!$this->httpClient) {
-            $this->httpClient = new \GuzzleHttp\Client();
+            // Using the default values of https://github.com/caseyamcl/guzzle_retry_middleware.
+            // Will trap 429 & 503 errors and retry (honouring `RetryAfter` header for 429's).
+            $stack = HandlerStack::create();
+            $stack->push(GuzzleRetryMiddleware::factory());
+
+            $this->httpClient = new \GuzzleHttp\Client([
+                'handler' => $stack
+            ]);
         }
         return $this->httpClient;
     }

--- a/src/Talis/Persona/Client/Base.php
+++ b/src/Talis/Persona/Client/Base.php
@@ -2,6 +2,8 @@
 
 namespace Talis\Persona\Client;
 
+use GuzzleHttp\HandlerStack;
+use GuzzleRetry\GuzzleRetryMiddleware;
 use Monolog\Logger;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
@@ -133,7 +135,19 @@ abstract class Base implements LoggerAwareInterface
      */
     protected function getHTTPClient($host)
     {
-        return new \GuzzleHttp\Client(['base_uri' => $host]);
+        // Using the default values of https://github.com/caseyamcl/guzzle_retry_middleware.
+        // Will trap 429 & 503 errors and retry (honouring `RetryAfter` header for 429's).
+        $stack = HandlerStack::create();
+        $stack->push(GuzzleRetryMiddleware::factory([
+            'on_retry_callback' => function ($attemptNumber, $delay) {
+                $this->getLogger()->warning("Persona retry #{$attemptNumber} after {$delay}s delay");
+            }
+        ]));
+
+        return new \GuzzleHttp\Client([
+            'base_uri' => $host,
+            'handler' => $stack
+        ]);
     }
 
     /**


### PR DESCRIPTION
* Add retry middleware (https://github.com/caseyamcl/guzzle_retry_middleware) to the Guzzle clients.
* For ones that are already 'LoggerAware', I've also added logging to show when retries happen.
* There are a couple of clients that are not currently 'LoggerAware' - I've not changed those to make them log - they just do the retries silently. That can be added in the future, if required.